### PR TITLE
New tests weren't ruffing.

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -245,8 +245,6 @@ def test_births_only_maintain_population_stability():
     populations = model.patches.populations[:, 0]
     assert np.all(populations == pop), "Population changed under Births_ConstantPop when it shouldn't"
 
-    
-
 
 @pytest.mark.modeltest
 def test_biweekly_scalar_modulates_transmission():
@@ -544,18 +542,18 @@ def test_targeted_importation_hits_correct_patch():
     model = Model(scenario, params)
     importation = Infect_Agents_In_Patch(model, verbose=params.verbose)  # Inject into patch 1
     model.components = [Births_ConstantPop, Susceptibility, Exposure, Infection, Transmission, importation]
-    #seed_infections_in_patch(model, ipatch=1, ninfections=1)
+    # seed_infections_in_patch(model, ipatch=1, ninfections=1)
     model.run()
 
     cases_patch0 = model.patches.cases_test[:, 0]
     cases_patch1 = model.patches.cases_test[:, 1]
 
-    #assert np.sum(cases_patch1) > 0, "Patch 1 should receive infections"
-    #assert np.sum(cases_patch0) == 0, "Patch 0 should remain uninfected"
+    # assert np.sum(cases_patch1) > 0, "Patch 1 should receive infections"
+    # assert np.sum(cases_patch0) == 0, "Patch 0 should remain uninfected"
     if not (np.sum(cases_patch1) > 0):
         print("🚨 Patch 1 cases:\n", cases_patch1)
         print("🚨 Total infections in Patch 1:", np.sum(cases_patch1))
-        assert False, "Patch 1 should receive infections"
+        pytest.fail("Patch 1 should receive infections")
 
     if not (np.sum(cases_patch0) == 0):
         print("🚨 Patch 0 cases:\n", cases_patch0)
@@ -563,9 +561,9 @@ def test_targeted_importation_hits_correct_patch():
         print("🚨 Full incidence matrix:\n", model.patches.incidence)
         print("🚨 Parameters:\n", params)
         print("🚨 Population state summary:")
-        print("  nodeid counts:", np.bincount(model.population.nodeid[:model.population.count]))
-        print("  infected states:", np.sum(model.population.state[:model.population.count] == 2))
-        assert False, "Patch 0 should remain uninfected"
+        print("  nodeid counts:", np.bincount(model.population.nodeid[: model.population.count]))
+        print("  infected states:", np.sum(model.population.state[: model.population.count] == 2))
+        pytest.fail("Patch 0 should remain uninfected")
 
 
 @pytest.mark.modeltest
@@ -606,7 +604,7 @@ def test_transmission_sir_behaves_like_transmission():
 
     # Optional: ensure they're similar (within ~20%)
     diff = np.abs(cases1 - cases2)
-    #assert np.max(diff) < 0.2 * pop, "Outputs of both transmissions should be similar"
+    # assert np.max(diff) < 0.2 * pop, "Outputs of both transmissions should be similar"
 
     if np.max(diff) >= 0.2 * pop:
         import matplotlib.pyplot as plt
@@ -627,4 +625,4 @@ def test_transmission_sir_behaves_like_transmission():
         plt.tight_layout()
         plt.savefig("test_transmission_comparison.png")  # Save for inspection
 
-        assert False, "Outputs of both transmissions differ significantly. See 'test_transmission_comparison.png'"
+        pytest.fail("Outputs of both transmissions differ significantly. See 'test_transmission_comparison.png'")

--- a/tests/test_model_sft.py
+++ b/tests/test_model_sft.py
@@ -80,16 +80,18 @@ def test_si_model_nobirths():
         cases = [model.patches.cases[i][0] for i in range(nticks)]
         popt, pcov = curve_fit(SI_logistic, t, cases, p0=[0.05, 1.1e5, 1])
 
-        output.append( pd.DataFrame.from_dict(
-            {
-                "seed": seed,
-                "beta": beta,
-                "cases": [np.array(cases)],
-                "fitted_beta": popt[0],
-                "fitted_size": popt[1],
-                "fitted_t0": popt[2],
-            }
-        ) )
+        output.append(
+            pd.DataFrame.from_dict(
+                {
+                    "seed": seed,
+                    "beta": beta,
+                    "cases": [np.array(cases)],
+                    "fitted_beta": popt[0],
+                    "fitted_size": popt[1],
+                    "fitted_t0": popt[2],
+                }
+            )
+        )
 
     assert np.all(np.abs((output["beta"] - output["fitted_beta"]) / output["beta"]) < 0.05)
 
@@ -141,18 +143,20 @@ def test_si_model_wbirths():
             p0=[beta * (1 + 0.1 * np.random.normal()), pop, cbr * (1 + 0.1 * np.random.normal()), 1],
             bounds=([0, pop - 1, 0, -100], [1, pop + 1, 600, 100]),
         )
-        output.append( pd.DataFrame.from_dict(
-            {
-                "seed": seed,
-                "beta": beta,
-                "cbr": cbr,
-                "cases": [np.array(cases)],
-                "fitted_beta": popt[0],
-                "fitted_size": popt[1],
-                "fitted_cbr": popt[2],
-                "fitted_t0": popt[3],
-            }
-        ) )
+        output.append(
+            pd.DataFrame.from_dict(
+                {
+                    "seed": seed,
+                    "beta": beta,
+                    "cbr": cbr,
+                    "cases": [np.array(cases)],
+                    "fitted_beta": popt[0],
+                    "fitted_size": popt[1],
+                    "fitted_cbr": popt[2],
+                    "fitted_t0": popt[3],
+                }
+            )
+        )
 
     assert np.all(np.abs((output["beta"] - output["fitted_beta"]) / output["beta"]) < 0.05)
     assert np.all(np.abs((output["cbr"] - output["fitted_cbr"]) / output["cbr"]) < 0.05)
@@ -206,17 +210,19 @@ def test_sir_nobirths():
             bounds=([betarange[0] / 2, pop - 1, gammarange[0] / 2, -300], [betarange[1] * 2, pop + 1, gammarange[1] * 2, 300]),
         )
 
-        output.append( pd.DataFrame.from_dict(
-            {
-                "seed": seed,
-                "beta": beta,
-                "gamma": gamma,
-                "cases": [np.array(cases)],
-                "fitted_beta": popt[0],
-                "fitted_gamma": popt[2],
-                "fitted_t0": popt[3],
-            }
-        ) )
+        output.append(
+            pd.DataFrame.from_dict(
+                {
+                    "seed": seed,
+                    "beta": beta,
+                    "gamma": gamma,
+                    "cases": [np.array(cases)],
+                    "fitted_beta": popt[0],
+                    "fitted_gamma": popt[2],
+                    "fitted_t0": popt[3],
+                }
+            )
+        )
 
     assert np.all(np.abs((output["beta"] - output["fitted_beta"]) / output["beta"]) < 0.05)
     assert np.all(np.abs((output["gamma"] - output["fitted_gamma"]) / output["gamma"]) < 0.1)


### PR DESCRIPTION
This is expected:
```
FAILED tests/test_model.py::test_sir_nobirths_short - AssertionError: Cases not consistent with incidence
FAILED tests/test_model.py::test_si_model_with_births_short - AttributeError: 'LaserFrame' object has no attribute 'etimer'
FAILED tests/test_model.py::test_sei_model_with_births_short - AttributeError: 'LaserFrame' object has no attribute 'etimer'. Did you mean: 'itimer'?
FAILED tests/test_model.py::test_sis_model_short - AssertionError: Susceptibles exceed population
FAILED tests/test_model.py::test_routine_immunization_blocks_spread - AssertionError: No transmission occurred
FAILED tests/test_model.py::test_mobility_spreads_infection_across_nodes - AssertionError: Cases not consistent with incidence
FAILED tests/test_model.py::test_births_only_maintain_population_stability - AttributeError: 'LaserFrame' object has no attribute 'etimer'
FAILED tests/test_model.py::test_biweekly_scalar_modulates_transmission - AssertionError: No transmission occurred
FAILED tests/test_model.py::test_births_variable_birthrate_maintains_population - AttributeError: 'LaserFrame' object has no attribute 'etimer'
FAILED tests/test_model.py::test_routine_immunization_blocks_spread_compare - AssertionError: Routine immunization should reduce infections
FAILED tests/test_model.py::test_immunization_campaign_temporarily_blocks_spread - AssertionError: Campaign should reduce infections during its window
FAILED tests/test_model.py::test_importation_keeps_infection_alive - AssertionError: Importation should maintain infections
FAILED tests/test_model.py::test_targeted_importation_hits_correct_patch - Failed: Patch 0 should remain uninfected
FAILED tests/test_model.py::test_transmission_sir_behaves_like_transmission - Failed: Outputs of both transmissions differ significantly. See 'test_transmission_comparison.png'
=========================================================================================================== 14 failed, 2 passed in 16.15s
```