### PR TITLE
Update tracking_id to property in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,7 +154,7 @@ extra:
 
   analytics:
     provider: custom
-    tracking_id: GTM-NK4K647
+    property: GTM-NK4K647
     feedback:
       title: Was this page helpful?
       ratings:


### PR DESCRIPTION
Wrong key name in the mkdocs.yml config for analytics tracking.