### PR TITLE
Update macOS version in GitHub Actions workflow

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -47,7 +47,7 @@ jobs:
             tox_env: 'py39'
             cibw_arch: 'x86_64'
             cibw_build: false
-            os: 'macos-13'
+            os: 'macos-15-intel'
           - name: 'py39 (macos/arm64)'
             python: '3.9'
             toxpython: 'python3.9'
@@ -79,7 +79,7 @@ jobs:
             tox_env: 'py310'
             cibw_arch: 'x86_64'
             cibw_build: false
-            os: 'macos-13'
+            os: 'macos-15-intel'
           - name: 'py310 (macos/arm64)'
             python: '3.10'
             toxpython: 'python3.10'
@@ -111,7 +111,7 @@ jobs:
             tox_env: 'py311'
             cibw_arch: 'x86_64'
             cibw_build: false
-            os: 'macos-13'
+            os: 'macos-15-intel'
           - name: 'py311 (macos/arm64)'
             python: '3.11'
             toxpython: 'python3.11'
@@ -143,7 +143,7 @@ jobs:
             tox_env: 'py312'
             cibw_arch: 'x86_64'
             cibw_build: false
-            os: 'macos-13'
+            os: 'macos-15-intel'
           - name: 'py312 (macos/arm64)'
             python: '3.12'
             toxpython: 'python3.12'


### PR DESCRIPTION
Put MacOS x86 testing on an (ostensibly) x86 equipped machine rather than emulated on an Apple Silicon machine.