### PR TITLE
🐛 avoid divide by zero on empty nodes

### DIFF
--- a/src/laser/generic/components.py
+++ b/src/laser/generic/components.py
@@ -1265,7 +1265,9 @@ class TransmissionSIx:
 
         N = _get_total_population(self, tick)
 
-        ft[:] = self.model.params.beta * self.seasonality[tick] * self.model.nodes.I[tick] / N
+        # If N is zero, then I is zero, so using 1 in the denominator is fine and will yield zero force of infection as expected
+        # and prevent a divide by zero error
+        ft[:] = self.model.params.beta * self.seasonality[tick] * self.model.nodes.I[tick] / np.maximum(N, 1)
         transfer = ft[:, None] * self.model.network
         ft += transfer.sum(axis=0)
         ft -= transfer.sum(axis=1)
@@ -1425,7 +1427,9 @@ class TransmissionSI:
 
         N = _get_total_population(self, tick)
 
-        ft[:] = self.model.params.beta * self.seasonality[tick] * self.model.nodes.I[tick] / N
+        # If N is zero, then I is zero, so using 1 in the denominator is fine and will yield zero force of infection as expected
+        # and prevent a divide by zero error
+        ft[:] = self.model.params.beta * self.seasonality[tick] * self.model.nodes.I[tick] / np.maximum(N, 1)
         transfer = ft[:, None] * self.model.network
         ft += transfer.sum(axis=0)
         ft -= transfer.sum(axis=1)
@@ -1591,7 +1595,9 @@ class TransmissionSE:
 
         N = _get_total_population(self, tick)
 
-        ft[:] = self.model.params.beta * self.seasonality[tick] * self.model.nodes.I[tick] / N
+        # If N is zero, then I is zero, so using 1 in the denominator is fine and will yield zero force of infection as expected
+        # and prevent a divide by zero error
+        ft[:] = self.model.params.beta * self.seasonality[tick] * self.model.nodes.I[tick] / np.maximum(N, 1)
         transfer = ft[:, None] * self.model.network
         ft += transfer.sum(axis=0)
         ft -= transfer.sum(axis=1)

--- a/src/laser/generic/components.py
+++ b/src/laser/generic/components.py
@@ -1265,9 +1265,7 @@ class TransmissionSIx:
 
         N = _get_total_population(self, tick)
 
-        # If N is zero, then I is zero, so using 1 in the denominator is fine and will yield zero force of infection as expected
-        # and prevent a divide by zero error
-        ft[:] = self.model.params.beta * self.seasonality[tick] * self.model.nodes.I[tick] / np.maximum(N, 1)
+        ft[:] = self.model.params.beta * self.seasonality[tick] * self.model.nodes.I[tick] / N
         transfer = ft[:, None] * self.model.network
         ft += transfer.sum(axis=0)
         ft -= transfer.sum(axis=1)
@@ -1427,9 +1425,7 @@ class TransmissionSI:
 
         N = _get_total_population(self, tick)
 
-        # If N is zero, then I is zero, so using 1 in the denominator is fine and will yield zero force of infection as expected
-        # and prevent a divide by zero error
-        ft[:] = self.model.params.beta * self.seasonality[tick] * self.model.nodes.I[tick] / np.maximum(N, 1)
+        ft[:] = self.model.params.beta * self.seasonality[tick] * self.model.nodes.I[tick] / N
         transfer = ft[:, None] * self.model.network
         ft += transfer.sum(axis=0)
         ft -= transfer.sum(axis=1)
@@ -1595,9 +1591,7 @@ class TransmissionSE:
 
         N = _get_total_population(self, tick)
 
-        # If N is zero, then I is zero, so using 1 in the denominator is fine and will yield zero force of infection as expected
-        # and prevent a divide by zero error
-        ft[:] = self.model.params.beta * self.seasonality[tick] * self.model.nodes.I[tick] / np.maximum(N, 1)
+        ft[:] = self.model.params.beta * self.seasonality[tick] * self.model.nodes.I[tick] / N
         transfer = ft[:, None] * self.model.network
         ft += transfer.sum(axis=0)
         ft -= transfer.sum(axis=1)
@@ -1636,7 +1630,7 @@ class TransmissionSE:
         return
 
 
-def _get_total_population(component, tick):
+def _get_total_population(component, tick, clamp: bool = True):
     """
     Helper to compute total population N at a given tick across all states.
 
@@ -1646,9 +1640,14 @@ def _get_total_population(component, tick):
     Checks to see if the component has a 'states' attribute; if not, it uses the model's states.
     Requires the component to have a model property with nodes LaserFrame that contain current state counts.
 
+    `clamp` causes the minimum N value to be 1 which avoids divide by zero warnings
+    when normalizing by node population. Since the actual S/E/I/R values must all be zero,
+    this will generally be safe and effective.
+
     Args:
         component: The model component containing the model and states.
         tick: The current time tick.
+        clamp: set minimum N to 1 to avoid divide-by-zero errors
 
     Returns:
         np.ndarray: Total population, shape = (#nodes,) array at the given tick.
@@ -1664,6 +1663,9 @@ def _get_total_population(component, tick):
         # Test for state, e.g., might not have 'E' or 'R' states
         if (prop := getattr(component.model.nodes, state, None)) is not None:
             N += prop[tick]
+
+    if clamp:
+        np.maximum(N, 1, out=N)
 
     return N
 

--- a/tests/age_at_infection.py
+++ b/tests/age_at_infection.py
@@ -22,6 +22,8 @@ On the given day(s), the component should look at the current number of suscepti
 Like the Transmission component, the step() function of this Importation component will have some NumPy code to calculate the per node probability of infection for susceptible agents and a Numba compiled function to process all the agents in parallel.
 """
 
+from pathlib import Path
+
 import matplotlib.pyplot as plt
 import numba as nb
 import numpy as np
@@ -34,7 +36,13 @@ from laser.generic.utils import ValuesMap
 from laser.generic.utils import validate
 from laser.generic.vitaldynamics import BirthsByCBR
 from laser.generic.vitaldynamics import MortalityByEstimator
-from utils import stdgrid
+
+try:
+    from tests.utils import stdgrid
+except ImportError:
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent))
+    from utils import stdgrid
 
 State = SEIR.State
 

--- a/tests/age_at_infection.py
+++ b/tests/age_at_infection.py
@@ -41,6 +41,7 @@ try:
     from tests.utils import stdgrid
 except ImportError:
     import sys
+
     sys.path.insert(0, str(Path(__file__).parent))
     from utils import stdgrid
 

--- a/tests/compare.py
+++ b/tests/compare.py
@@ -21,7 +21,13 @@ from laser.generic import SIRS
 from laser.generic import SEIR
 from laser.generic import SEIRS
 from laser.generic import Model
-from utils import stdgrid
+
+try:
+    from tests.utils import stdgrid
+except ImportError:
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent))
+    from utils import stdgrid
 
 EM = 10
 EN = 10

--- a/tests/compare.py
+++ b/tests/compare.py
@@ -26,6 +26,7 @@ try:
     from tests.utils import stdgrid
 except ImportError:
     import sys
+
     sys.path.insert(0, str(Path(__file__).parent))
     from utils import stdgrid
 

--- a/tests/mabs_example.py
+++ b/tests/mabs_example.py
@@ -6,6 +6,7 @@ adding a MaternalAntibodies component that gives newborns temporary immunity via
 """
 
 from argparse import ArgumentParser
+from pathlib import Path
 
 import laser.core.distributions as dists
 import numba as nb
@@ -21,8 +22,17 @@ from laser.generic import Model
 from laser.generic.utils import ValuesMap
 from laser.generic.vitaldynamics import BirthsByCBR
 from laser.generic.vitaldynamics import MortalityByEstimator
-from age_at_infection import TransmissionWithDOI
-from utils import stdgrid
+
+
+try:
+    from tests.age_at_infection import TransmissionWithDOI
+    from tests.utils import stdgrid
+except ImportError:
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent))
+    from age_at_infection import TransmissionWithDOI
+    from utils import stdgrid
+
 
 State = SEIR.State
 

--- a/tests/mabs_example.py
+++ b/tests/mabs_example.py
@@ -29,6 +29,7 @@ try:
     from tests.utils import stdgrid
 except ImportError:
     import sys
+
     sys.path.insert(0, str(Path(__file__).parent))
     from age_at_infection import TransmissionWithDOI
     from utils import stdgrid

--- a/tests/test_seir.py
+++ b/tests/test_seir.py
@@ -22,6 +22,7 @@ try:
     from tests.utils import stdgrid
 except ImportError:
     import sys
+
     sys.path.insert(0, str(Path(__file__).parent))
     from utils import stdgrid
 
@@ -446,7 +447,7 @@ class Default(unittest.TestCase):
                 EM,
                 EN,
                 # Set one corner to 0 population
-                lambda x, y: int(np.random.uniform(10_000, 1_000_000)) if (x+y) > 0 else 0,
+                lambda x, y: int(np.random.uniform(10_000, 1_000_000)) if (x + y) > 0 else 0,
                 init_infected=10,
                 birthrates=birthrate_map.values,
                 pyramid=pyramid,

--- a/tests/test_seir.py
+++ b/tests/test_seir.py
@@ -17,7 +17,13 @@ from laser.generic import SEIR
 from laser.generic import Model
 from laser.generic.utils import ValuesMap
 from laser.generic.vitaldynamics import BirthsByCBR, MortalityByEstimator
-from tests.utils import stdgrid
+
+try:
+    from tests.utils import stdgrid
+except ImportError:
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent))
+    from utils import stdgrid
 
 PLOTTING = False
 VERBOSE = False
@@ -39,12 +45,12 @@ def build_model(m, n, pop_fn, init_infected=0, init_recovered=0, birthrates=None
     optional birth and mortality processes.
     """
     scenario = stdgrid(M=m, N=n, population_fn=pop_fn)
-    scenario["S"] = scenario["population"]
+    scenario["S"] = scenario.population
     scenario["E"] = 0
-    scenario["S"] -= init_infected
-    scenario["I"] = init_infected
-    scenario["S"] -= init_recovered
-    scenario["R"] = init_recovered
+    scenario["I"] = np.minimum(init_infected, scenario.S)
+    scenario["S"] -= scenario.I
+    scenario["R"] = np.minimum(init_recovered, scenario.S)
+    scenario["S"] -= scenario.R
 
     if not beta:
         beta = R0 / INFECTIOUS_DURATION_MEAN
@@ -429,6 +435,30 @@ class Default(unittest.TestCase):
             assert np.all(I_series >= 0)
             assert np.all(R >= 0)
 
+    def test_grid_with_zero_pop_nodes(self):
+        with ts.start("test_grid"):
+            cbr = np.random.uniform(5, 35, EM * EN)
+            birthrate_map = ValuesMap.from_nodes(cbr, nticks=NTICKS)
+            pyramid = AliasedDistribution(np.full(89, 1_000))
+            survival = KaplanMeierEstimator(np.full(89, 1_000).cumsum())
+
+            model = build_model(
+                EM,
+                EN,
+                # Set one corner to 0 population
+                lambda x, y: int(np.random.uniform(10_000, 1_000_000)) if (x+y) > 0 else 0,
+                init_infected=10,
+                birthrates=birthrate_map.values,
+                pyramid=pyramid,
+                survival=survival,
+            )
+            model.run("SEIR Grid")
+
+            I_series = model.nodes.I.sum(axis=1)
+            assert I_series.max() > I_series[0], "Infections did not increase from initial count during simulation."
+
+        return
+
 
 if __name__ == "__main__":
     parser = ArgumentParser()
@@ -441,8 +471,9 @@ if __name__ == "__main__":
     parser.add_argument("-t", "--ticks", type=int, default=365, help="Number of days to simulate (nticks)")
     parser.add_argument("-r", "--r0", type=float, default=1.386, help="R0")
     parser.add_argument("-g", "--grid", action="store_true", help="Run grid spatial test")
-    parser.add_argument("-l", "--linear", action="store_true", help="Run linear spatial test")
+    parser.add_argument("-l", "--linear", action="store_true", help="Run linear spatial tests")
     parser.add_argument("-s", "--single", action="store_true", help="Run single node test (not spatial)")
+    parser.add_argument("-z", "--zero", action="store_true", help="Run grid with zero pop node test")
     parser.add_argument("unittest", nargs="*")
 
     args = parser.parse_args()
@@ -456,7 +487,7 @@ if __name__ == "__main__":
     print(f"Using arguments {args=}")
 
     tc = Default()
-    run_all = not (args.grid or args.linear or args.single)
+    run_all = not (args.grid or args.linear or args.single or args.zero)
 
     if args.single or run_all:
         tc.test_single()
@@ -465,6 +496,8 @@ if __name__ == "__main__":
     if args.linear or run_all:
         tc.test_seir_linear_no_demography()
         tc.test_seir_linear_with_demography()
+    if args.zero or run_all:
+        tc.test_grid_with_zero_pop_nodes()
 
     ts.freeze()
     print("\nTiming Summary:")

--- a/tests/test_seirs.py
+++ b/tests/test_seirs.py
@@ -22,6 +22,7 @@ try:
     from tests.utils import stdgrid
 except ImportError:
     import sys
+
     sys.path.insert(0, str(Path(__file__).parent))
     from utils import stdgrid
 
@@ -471,7 +472,7 @@ class Default(unittest.TestCase):
             model = build_model(
                 EM,
                 EN,
-                lambda x, y: int(np.random.uniform(10_000, 1_000_000)) if (x+y) > 0 else 0,
+                lambda x, y: int(np.random.uniform(10_000, 1_000_000)) if (x + y) > 0 else 0,
                 init_infected=10,
                 birthrates=birthrate_map.values,
                 pyramid=pyramid,

--- a/tests/test_seirs.py
+++ b/tests/test_seirs.py
@@ -17,7 +17,13 @@ from laser.generic import SEIRS
 from laser.generic import Model
 from laser.generic.utils import ValuesMap
 from laser.generic.vitaldynamics import BirthsByCBR, MortalityByEstimator
-from tests.utils import stdgrid
+
+try:
+    from tests.utils import stdgrid
+except ImportError:
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent))
+    from utils import stdgrid
 
 PLOTTING = False
 VERBOSE = False
@@ -41,12 +47,12 @@ def build_model(m, n, pop_fn, init_infected=0, init_recovered=0, birthrates=None
     optionally adding demographic processes (births and deaths).
     """
     scenario = stdgrid(M=m, N=n, population_fn=pop_fn)
-    scenario["S"] = scenario["population"]
+    scenario["S"] = scenario.population
     scenario["E"] = 0
-    scenario["S"] -= init_infected
-    scenario["I"] = init_infected
-    scenario["S"] -= init_recovered
-    scenario["R"] = init_recovered
+    scenario["I"] = np.minimum(init_infected, scenario.S)
+    scenario["S"] -= scenario.I
+    scenario["R"] = np.minimum(init_recovered, scenario.S)
+    scenario["S"] -= scenario.R
 
     if not beta:
         beta = R0 / INFECTIOUS_DURATION_MEAN
@@ -455,6 +461,51 @@ class Default(unittest.TestCase):
             assert np.all(I_series >= 0)
             assert np.all(R_series >= 0)
 
+    def test_grid_with_zero_pop_node(self):
+        with ts.start("test_grid"):
+            cbr = np.random.uniform(5, 35, EM * EN)
+            birthrate_map = ValuesMap.from_nodes(cbr, nticks=NTICKS)
+            pyramid = AliasedDistribution(np.full(89, 1_000))
+            survival = KaplanMeierEstimator(np.full(89, 1_000).cumsum())
+
+            model = build_model(
+                EM,
+                EN,
+                lambda x, y: int(np.random.uniform(10_000, 1_000_000)) if (x+y) > 0 else 0,
+                init_infected=10,
+                birthrates=birthrate_map.values,
+                pyramid=pyramid,
+                survival=survival,
+            )
+            model.run("SEIRS Grid")
+
+            I_series = model.nodes.I.sum(axis=1)
+            E_series = model.nodes.E.sum(axis=1)
+            R_series = model.nodes.R.sum(axis=1)
+            N_series = (model.nodes.S + model.nodes.E + model.nodes.I + model.nodes.R).sum(axis=1)
+            pop_change = (N_series[-1] - N_series[0]) / N_series[0]
+            mean_prev = (model.nodes.I / (model.nodes.S + model.nodes.E + model.nodes.I + model.nodes.R + 1e-9)).mean()
+
+            assert np.all(model.nodes.S >= 0)
+            assert np.all(model.nodes.E >= 0)
+            assert np.all(model.nodes.I >= 0)
+            assert np.all(model.nodes.R >= 0)
+            assert abs(pop_change) < 0.1, f"Population drift {pop_change * 100:.2f}% >10%"
+            assert mean_prev <= 0.5, f"Mean prevalence {mean_prev:.3f} >0.5"
+            # assert np.argmax(E_series) < np.argmax(I_series), "E before I"
+            # assert np.argmax(I_series) < np.argmax(R_series), "I before R"
+
+            # Latent period must exist: E must rise early
+            assert E_series[5] > E_series[0], "E did not rise early (SEIR/SEIRS latency broken)."
+
+            # Infectiousness rises after exposure
+            assert I_series[10] > I_series[0], "I did not rise after early E growth."
+
+            # Recovered must accumulate beyond infectious at some point (even in waning systems)
+            assert R_series.max() >= I_series.max(), "Recovered never exceeded infectious — unusual for SEIRS dynamics."
+
+        return
+
 
 if __name__ == "__main__":
     parser = ArgumentParser()
@@ -469,6 +520,7 @@ if __name__ == "__main__":
     parser.add_argument("-g", "--grid", action="store_true", help="Run spatial grid test")
     parser.add_argument("-l", "--linear", action="store_true", help="Run spatial linear test")
     parser.add_argument("-s", "--single", action="store_true", help="Run single node (non-spatial) test")
+    parser.add_argument("-z", "--zero", action="store_true", help="Run grid with zero pop node test")
     parser.add_argument("unittest", nargs="*")
 
     args = parser.parse_args()
@@ -482,14 +534,17 @@ if __name__ == "__main__":
     print(f"Using arguments {args=}")
 
     tc = Default()
-    run_all = not (args.grid or args.linear or args.single)
+    run_all = not (args.grid or args.linear or args.single or args.zero)
 
     if args.single or run_all:
         tc.test_single()
     if args.grid or run_all:
         tc.test_grid()
     if args.linear or run_all:
-        tc.test_linear()
+        tc.test_seirs_linear_no_demography()
+        tc.test_seirs_linear_with_demography()
+    if args.zero or run_all:
+        tc.test_grid_with_zero_pop_node()
 
     ts.freeze()
     print("\nTiming Summary:")

--- a/tests/test_si.py
+++ b/tests/test_si.py
@@ -14,8 +14,16 @@ from laser.generic import Model
 from laser.generic.utils import ValuesMap
 from laser.core.utils import grid
 from laser.generic.vitaldynamics import ConstantPopVitalDynamics
-from tests.utils import base_maps
-from tests.utils import stdgrid
+
+try:
+    from tests.utils import base_maps
+    from tests.utils import stdgrid
+except ImportError:
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent))
+    from utils import base_maps
+    from utils import stdgrid
+
 
 PLOTTING = False
 VERBOSE = False
@@ -303,6 +311,42 @@ class Default(unittest.TestCase):
 
         return
 
+    def test_grid_with_empty_nodes(self):
+        """
+        Setup like test_grid(), but set two nodes to zero population.
+        """
+        with ts.start("test_grid_with_empty_nodes"):
+            scenario = stdgrid(M=EM, N=EN)
+            scenario["S"] = scenario.population - 10
+            scenario["I"] = 10
+            # Set row 0 and last row to zero population, both S and I
+            idx = 0
+            scenario.loc[idx, "population"] = scenario.loc[idx, "S"] = scenario.loc[idx, "I"] = 0
+            idx = len(scenario) - 1
+            scenario.loc[idx, "population"] = scenario.loc[idx, "S"] = scenario.loc[idx, "I"] = 0
+
+            cbr = np.random.uniform(5, 35, len(scenario))  # CBR = per 1,000 per year
+            birthrate_map = ValuesMap.from_nodes(cbr, nticks=NTICKS)
+
+            params = PropertySet({"nticks": NTICKS, "beta": 1.0 / 32})
+
+            with ts.start("Model Initialization"):
+                model = Model(scenario, params, birthrate_map)
+                model.validating = VALIDATING
+
+                s = SI.Susceptible(model)
+                i = SI.Infectious(model)
+                tx = SI.Transmission(model)
+                # births = BirthsByCBR(model, birthrate_map, pyramid)
+                # mortality = MortalityByEstimator(model, survival)
+                model.components = [s, i, tx]  # , births, mortality]
+
+            model.run(f"SI Grid ({model.people.count:,}/{model.nodes.count:,})")
+
+            initial_I = model.nodes.I[0].sum()
+            final_I = model.nodes.I[-1].sum()
+            assert final_I != pytest.approx(initial_I), "Infection count should evolve over time."
+
 
 if __name__ == "__main__":
     parser = ArgumentParser()
@@ -316,6 +360,7 @@ if __name__ == "__main__":
     parser.add_argument("-g", "--grid", action="store_true", help="Run grid test")
     parser.add_argument("-l", "--linear", action="store_true", help="Run linear test")
     parser.add_argument("-c", "--constant", action="store_true", help="Run constant population test")
+    parser.add_argument("-z", "--zero", action="store_true", help="Run zero population nodes test")
     parser.add_argument("unittest", nargs="*")
 
     args = parser.parse_args()
@@ -332,7 +377,7 @@ if __name__ == "__main__":
     tc = Default()
 
     # If no test flags were given, run all by default
-    run_all = not (args.grid or args.linear or args.constant)
+    run_all = not (args.grid or args.linear or args.constant or args.zero)
 
     if args.grid or run_all:
         print("\nRunning grid configuration...")
@@ -345,6 +390,10 @@ if __name__ == "__main__":
     if args.constant:
         print("\nRunning constant population configuration...")
         tc.test_constant_pop()
+
+    if args.zero:
+        print("\nRunning zero population nodes test...")
+        tc.test_grid_with_empty_nodes()
 
     ts.freeze()
     print("\nTiming Summary:")

--- a/tests/test_si.py
+++ b/tests/test_si.py
@@ -20,6 +20,7 @@ try:
     from tests.utils import stdgrid
 except ImportError:
     import sys
+
     sys.path.insert(0, str(Path(__file__).parent))
     from utils import base_maps
     from utils import stdgrid

--- a/tests/test_sir.py
+++ b/tests/test_sir.py
@@ -21,6 +21,7 @@ try:
     from tests.utils import stdgrid
 except ImportError:
     import sys
+
     sys.path.insert(0, str(Path(__file__).parent))
     from utils import stdgrid
 
@@ -445,7 +446,6 @@ class Default(unittest.TestCase):
         return
 
     def test_grid_with_zero_pop_nodes(self):
-
         with ts.start("test_grid"):
             scenario = stdgrid(M=EM, N=EN)
             scenario["S"] = scenario["population"] - 10

--- a/tests/test_sir.py
+++ b/tests/test_sir.py
@@ -16,7 +16,14 @@ from laser.generic import SIR
 from laser.generic import Model
 from laser.generic.utils import ValuesMap
 from laser.generic.vitaldynamics import BirthsByCBR, MortalityByEstimator
-from tests.utils import stdgrid
+
+try:
+    from tests.utils import stdgrid
+except ImportError:
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent))
+    from utils import stdgrid
+
 
 PLOTTING = False
 VERBOSE = False
@@ -435,6 +442,58 @@ class Default(unittest.TestCase):
                 f"Kermack-McKendrick test failed {failed}/{NITERS} for R0={beta * inf_mean:.3f} (expected AF={expected_af:.3f})"
             )
 
+        return
+
+    def test_grid_with_zero_pop_nodes(self):
+
+        with ts.start("test_grid"):
+            scenario = stdgrid(M=EM, N=EN)
+            scenario["S"] = scenario["population"] - 10
+            scenario["I"] = 10
+            scenario["R"] = 0
+
+            idx = 0
+            scenario.loc[idx, "population"] = scenario.loc[idx, "S"] = scenario.loc[idx, "I"] = 0
+            idx = len(scenario) - 1
+            scenario.loc[idx, "population"] = scenario.loc[idx, "S"] = scenario.loc[idx, "I"] = 0
+
+            cbr = np.random.uniform(5, 35, len(scenario))
+            birthrate_map = ValuesMap.from_nodes(cbr, nticks=NTICKS)
+            infectious_duration_mean = 7.0
+            beta = R0 / infectious_duration_mean
+            params = PropertySet({"nticks": NTICKS, "beta": beta})
+
+            with ts.start("Model Initialization"):
+                model = Model(scenario, params, birthrates=birthrate_map)
+                infdist = dists.normal(loc=infectious_duration_mean, scale=2)
+                pyramid = AliasedDistribution(np.full(89, 1_000))
+                survival = KaplanMeierEstimator(np.full(89, 1_000).cumsum())
+                s = SIR.Susceptible(model)
+                i = SIR.Infectious(model, infdist)
+                r = SIR.Recovered(model)
+                tx = SIR.Transmission(model, infdist)
+                births = BirthsByCBR(model, birthrates=birthrate_map, pyramid=pyramid)
+                mortality = MortalityByEstimator(model, survival)
+                model.components = [s, i, r, tx, births, mortality]
+                model.validating = VALIDATING
+
+            model.run("SIR Grid")
+
+            # --- Quantitative Checks ---
+            I_series = model.nodes.I.sum(axis=1)
+            N_series = (model.nodes.S + model.nodes.I + model.nodes.R).sum(axis=1)
+            pop_change = (N_series[-1] - N_series[0]) / N_series[0]
+            mean_prev = (model.nodes.I / (model.nodes.S + model.nodes.I + model.nodes.R + 1e-9)).mean()
+
+            assert np.all(model.nodes.S >= 0)
+            assert np.all(model.nodes.I >= 0)
+            assert np.all(model.nodes.R >= 0)
+            assert abs(pop_change) < 0.1, f"Population drift {pop_change * 100:.2f}% exceeds ±10%."
+            assert 0 <= mean_prev <= 0.5, f"Mean prevalence unrealistic: {mean_prev:.3f}"
+            assert I_series.max() > I_series[0] * 1.5, "Epidemic growth not observed."
+
+        return
+
 
 if __name__ == "__main__":
     parser = ArgumentParser()
@@ -447,8 +506,9 @@ if __name__ == "__main__":
     parser.add_argument("-r", "--r0", type=float, default=1.386, help="R0")
     parser.add_argument("-t", "--ticks", type=int, default=365, help="Number of days to simulate (nticks)")
     parser.add_argument("-g", "--grid", action="store_true", help="Run spatial grid test")
-    parser.add_argument("-l", "--linear", action="store_true", help="Run spatial linear test")
+    parser.add_argument("-l", "--linear", action="store_true", help="Run spatial linear tests")
     parser.add_argument("-s", "--single", action="store_true", help="Run single node (non-spatial) test")
+    parser.add_argument("-z", "--zero", action="store_true", help="Run grid test with zero pop nodes")
     parser.add_argument("-k", "--km", action="store_true", help="Run Kermack-McKendrick validation")
     parser.add_argument("unittest", nargs="*")
 
@@ -463,14 +523,17 @@ if __name__ == "__main__":
     print(f"Using arguments {args=}")
 
     tc = Default()
-    run_all = not (args.grid or args.linear or args.single or args.km)
+    run_all = not (args.grid or args.linear or args.single or args.km or args.zero)
 
     if args.single or run_all:
         tc.test_single()
     if args.grid or run_all:
         tc.test_grid()
     if args.linear or run_all:
-        tc.test_linear()
+        tc.test_sir_linear_no_demography()
+        tc.test_sir_linear_with_demography()
+    if args.zero or run_all:
+        tc.test_grid_with_zero_pop_nodes()
     if args.km or run_all:
         tc.test_kermack_mckendrick()
 

--- a/tests/test_sirs.py
+++ b/tests/test_sirs.py
@@ -15,7 +15,14 @@ from laser.generic import SIRS
 from laser.generic import Model
 from laser.generic.utils import ValuesMap
 from laser.generic.vitaldynamics import BirthsByCBR, MortalityByEstimator
-from tests.utils import stdgrid
+
+try:
+    from tests.utils import stdgrid
+except ImportError:
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent))
+    from utils import stdgrid
+
 
 PLOTTING = False
 VERBOSE = False
@@ -34,11 +41,11 @@ def build_model(m, n, pop_fn, init_infected=0, init_recovered=0, birthrates=None
     Helper: Construct an SIRS model with optional demography and waning immunity.
     """
     scenario = stdgrid(M=m, N=n, population_fn=pop_fn)
-    scenario["S"] = scenario["population"]
-    scenario["S"] -= init_infected
-    scenario["I"] = init_infected
-    scenario["S"] -= init_recovered
-    scenario["R"] = init_recovered
+    scenario["S"] = scenario.population
+    scenario["I"] = np.minimum(init_infected, scenario.S)
+    scenario["S"] -= scenario.I
+    scenario["R"] = np.minimum(init_recovered, scenario.S)
+    scenario["S"] -= scenario.R
 
     beta = R0 / INFECTIOUS_DURATION_MEAN
     params = PropertySet({"nticks": NTICKS, "beta": beta})
@@ -367,6 +374,29 @@ class Default(unittest.TestCase):
             # 5. waning immunity should still reduce R at some point
             assert R_series.max() > R_series[-1], "Waning immunity not visible (R never declines)."
 
+    def test_grid_with_zero_pop_nodes(self):
+        with ts.start("test_grid"):
+            cbr = np.random.uniform(5, 35, EM * EN)
+            birthrate_map = ValuesMap.from_nodes(cbr, nticks=NTICKS)
+            pyramid = AliasedDistribution(np.full(89, 1_000))
+            survival = KaplanMeierEstimator(np.full(89, 1_000).cumsum())
+
+            model = build_model(
+                EM,
+                EN,
+                # Set one corner to zero population
+                lambda x, y: int(np.random.uniform(10_000, 1_000_000)) if (x+y) > 0 else 0,
+                init_infected=10,
+                birthrates=birthrate_map.values,
+                pyramid=pyramid,
+                survival=survival,
+            )
+            model.run("SIRS Grid")
+
+            I_series = model.nodes.I.sum(axis=1)
+            assert I_series.max() > I_series[0], "Infections did not increase from initial count during simulation."
+
+        return
 
 if __name__ == "__main__":
     parser = ArgumentParser()
@@ -385,8 +415,9 @@ if __name__ == "__main__":
         help="Basic reproduction number (R0) [1.151 for 25%% attack fraction, 1.386=50%%, and 1.848=75%%]",
     )
     parser.add_argument("-g", "--grid", action="store_true", help="Run grid test")
-    parser.add_argument("-l", "--linear", action="store_true", help="Run linear test")
+    parser.add_argument("-l", "--linear", action="store_true", help="Run linear tests")
     parser.add_argument("-s", "--single", action="store_true", help="Run single node test")
+    parser.add_argument("-z", "--zero", action="store_true", help="Run zero population node test")
     parser.add_argument("-i", "--infdur", type=float, default=7.0, help="Mean infectious duration in days")
     parser.add_argument("-w", "--wandur", type=float, default=30.0, help="Mean waning duration in days")
     parser.add_argument("unittest", nargs="*")
@@ -402,14 +433,17 @@ if __name__ == "__main__":
     print(f"Using arguments {args=}")
 
     tc = Default()
-    run_all = not (args.grid or args.linear or args.single)
+    run_all = not (args.grid or args.linear or args.single or args.zero)
 
     if args.single or run_all:
         tc.test_single()
     if args.grid or run_all:
         tc.test_grid()
     if args.linear or run_all:
-        tc.test_linear()
+        tc.test_sirs_linear_no_demography()
+        tc.test_sirs_linear_with_demography()
+    if args.zero or run_all:
+        tc.test_grid_with_zero_pop_nodes()
 
     ts.freeze()
     print("\nTiming Summary:")

--- a/tests/test_sirs.py
+++ b/tests/test_sirs.py
@@ -20,6 +20,7 @@ try:
     from tests.utils import stdgrid
 except ImportError:
     import sys
+
     sys.path.insert(0, str(Path(__file__).parent))
     from utils import stdgrid
 
@@ -385,7 +386,7 @@ class Default(unittest.TestCase):
                 EM,
                 EN,
                 # Set one corner to zero population
-                lambda x, y: int(np.random.uniform(10_000, 1_000_000)) if (x+y) > 0 else 0,
+                lambda x, y: int(np.random.uniform(10_000, 1_000_000)) if (x + y) > 0 else 0,
                 init_infected=10,
                 birthrates=birthrate_map.values,
                 pyramid=pyramid,
@@ -397,6 +398,7 @@ class Default(unittest.TestCase):
             assert I_series.max() > I_series[0], "Infections did not increase from initial count during simulation."
 
         return
+
 
 if __name__ == "__main__":
     parser = ArgumentParser()

--- a/tests/test_sis.py
+++ b/tests/test_sis.py
@@ -15,8 +15,16 @@ from laser.generic.utils import TimingStats as ts
 from laser.generic.utils import ValuesMap
 from laser.generic.vitaldynamics import BirthsByCBR
 from laser.generic.vitaldynamics import MortalityByEstimator
-from tests.utils import base_maps
-from tests.utils import stdgrid
+
+try:
+    from tests.utils import base_maps
+    from tests.utils import stdgrid
+except ImportError:
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent))
+    from utils import base_maps
+    from utils import stdgrid
+
 
 PLOTTING = False
 VERBOSE = False
@@ -199,6 +207,72 @@ class Default(unittest.TestCase):
             model.basemap_provider = base_maps[ibm]
             print(f"Using basemap: {model.basemap_provider.name}")
             model.plot()
+
+    def test_grid_with_zero_pop_nodes(self):
+        with ts.start("test_grid"):
+            grd = stdgrid(
+                M=EM,
+                N=EN,
+                node_size_degs=0.08983,
+                population_fn=lambda x, y: int(np.random.uniform(10_000, 1_000_000)),
+                origin_x=-119.204167,
+                origin_y=40.786944,
+            )
+            scenario = grd
+            scenario["S"] = scenario["population"] - 10
+            scenario["I"] = 10
+
+            for idx in [0, len(scenario) - 1]:
+                scenario.loc[idx, "population"] = scenario.loc[idx, "S"] = scenario.loc[idx, "I"] = 0
+
+            # --- Basic population sanity ---
+            assert np.all(scenario["S"] >= 0)
+            assert np.all(scenario["I"] >= 0)
+            np.testing.assert_array_equal(scenario["S"] + scenario["I"], scenario["population"])
+
+            # Birthrates and parameters
+            cbr = np.random.uniform(5, 35, len(scenario))  # per 1,000 per year
+            birthrate_map = ValuesMap.from_nodes(cbr, nticks=NTICKS)
+
+            R0 = 1.2
+            infectious_duration_mean = 7.0
+            beta = R0 / infectious_duration_mean
+            params = PropertySet({"nticks": NTICKS, "beta": beta})
+
+            with ts.start("Model Initialization"):
+                model = Model(scenario, params, birthrates=birthrate_map)
+
+                infdist = dists.normal(loc=infectious_duration_mean, scale=2)
+                pyramid = AliasedDistribution(np.full(89, 1_000))
+                survival = KaplanMeierEstimator(np.full(89, 1_000).cumsum())
+
+                s = SIS.Susceptible(model)
+                i = SIS.Infectious(model, infdist)
+                tx = SIS.Transmission(model, infdist)
+                births = BirthsByCBR(model, birthrate_map, pyramid)
+                mortality = MortalityByEstimator(model, survival)
+                model.components = [s, i, tx, births, mortality]
+
+                model.validating = VALIDATING
+
+            # Run model
+            model.run(f"SIS Grid ({model.people.count:,}/{model.nodes.count:,})")
+
+        # --- Post-simulation checks ---
+        I_series = model.nodes.I.sum(axis=1)
+        assert I_series.max() > I_series[0], "Infections did not increase from initial count during simulation."
+
+        if VERBOSE:
+            print(model.people.describe("People"))
+            print(model.nodes.describe("Nodes"))
+
+        if PLOTTING:
+            ibm = np.random.choice(len(base_maps))
+            model.basemap_provider = base_maps[ibm]
+            print(f"Using basemap: {model.basemap_provider.name}")
+            model.plot()
+
+        return
 
 
 if __name__ == "__main__":

--- a/tests/test_sis.py
+++ b/tests/test_sis.py
@@ -21,6 +21,7 @@ try:
     from tests.utils import stdgrid
 except ImportError:
     import sys
+
     sys.path.insert(0, str(Path(__file__).parent))
     from utils import base_maps
     from utils import stdgrid

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -13,6 +13,7 @@ Components tested:
 """
 
 import unittest
+from pathlib import Path
 
 import laser.core.distributions as dists
 import numpy as np
@@ -45,16 +46,15 @@ from laser.generic.vitaldynamics import (
 from laser.core.demographics import KaplanMeierEstimator
 from laser.generic.shared import AliasedDistribution
 
-
-try:
-    from tests.utils import stdgrid
-except ImportError:
-    from utils import stdgrid
-
 try:
     from tests.age_at_infection import Importation, TransmissionWithDOI
+    from tests.utils import stdgrid
 except ImportError:
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent))
     from age_at_infection import Importation, TransmissionWithDOI
+    from utils import stdgrid
+
 
 # Test parameters
 NTICKS = 100

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -51,6 +51,7 @@ try:
     from tests.utils import stdgrid
 except ImportError:
     import sys
+
     sys.path.insert(0, str(Path(__file__).parent))
     from age_at_infection import Importation, TransmissionWithDOI
     from utils import stdgrid


### PR DESCRIPTION
`laser-init` found some geographies with empty (zero population) nodes which causes a div by zero problem in the force of infection calculation
