### PR TITLE
#49 adds jupyter notebook execution to the mkdocs build used for rele…

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -39,7 +39,7 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: build
+    needs: [build, docs-deploy]
     runs-on: ubuntu-latest
 
     steps:
@@ -73,7 +73,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    needs: build
+    needs: [build, docs-deploy]
     runs-on: ubuntu-latest
     environment:
       name: restricted
@@ -109,3 +109,32 @@ jobs:
           packages-dir: final_dist
           verbose: true
           print-hash: true
+
+  docs-deploy:
+    name: Execute notebooks and deploy docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - name: Install dependencies
+        run: |
+          pip install -e .
+          pip install mkdocs mkdocs-material
+          pip install -r docs/requirements.txt
+      - name: Build and deploy docs (executes notebooks)
+        run: mkdocs gh-deploy --force --config-file mkdocs.ci.yml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -34,6 +34,7 @@ global-exclude *.so *.dylib *.gz
 exclude CLAUDE.md
 exclude convert_clean.sh
 exclude mkdocs.yml
+exclude mkdocs.ci.yml
 exclude mkdocs_jenner.yml
 exclude laserdocs_sphinx/*
 exclude tests/harvest_test_docstrings.py

--- a/mkdocs.ci.yml
+++ b/mkdocs.ci.yml
@@ -1,0 +1,6 @@
+INHERIT: mkdocs.yml
+
+plugins:
+  - mkdocs-jupyter:
+      execute: true
+      allow_errors: false


### PR DESCRIPTION
…asing the package

This update means the release is gated on successful execution of the notebooks, and would allow updates to the notebooks in between releases to potentially overwrite a validated notebook. The risk is errors in the notebooks being allowed to accumulate and not discovering them until the release is attempted, at which point they would need to be fixed. However, it means we don't risk sharing incorrect tutorials with users or Jenner and that the build time for all PRs is reduced significantly.