### PR TITLE
refactor: move docs/requirements.txt into pyproject.toml [docs] extra…

### DIFF
--- a/.github/workflows/mkdocs-ghp.yml
+++ b/.github/workflows/mkdocs-ghp.yml
@@ -26,7 +26,5 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: |
-          pip install -e .
-          pip install mkdocs mkdocs-material # Or your specific theme and plugins
-          pip install -r docs/requirements.txt  # If you have a requirements.txt file
+          pip install --index-url https://packages.idmod.org/artifactory/api/pypi/pypi-production/simple -e ".[docs]"
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/mkdocs-pr.yml
+++ b/.github/workflows/mkdocs-pr.yml
@@ -19,9 +19,7 @@ jobs:
 
     - name: Install MkDocs and dependencies
       run: |
-        pip install -e .
-        pip install mkdocs mkdocs-material # Or your specific theme and plugins
-        pip install -r docs/requirements.txt  # If you have a requirements.txt file
+        pip install --index-url https://packages.idmod.org/artifactory/api/pypi/pypi-production/simple -e ".[docs]"
 
     - name: Build MkDocs site
       run: mkdocs build

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -133,8 +133,6 @@ jobs:
             mkdocs-material-
       - name: Install dependencies
         run: |
-          pip install -e .
-          pip install mkdocs mkdocs-material
-          pip install -r docs/requirements.txt
+          pip install --index-url https://packages.idmod.org/artifactory/api/pypi/pypi-production/simple -e ".[docs]"
       - name: Build and deploy docs (executes notebooks)
         run: mkdocs gh-deploy --force --config-file mkdocs.ci.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,30 @@ dev = [
   "uv>=0.10.6",
 ]
 
+docs = [
+  # mkdocs ecosystem
+  "mkdocs-material",
+  "mkdocs-include-markdown-plugin",
+  "mkdocs-autorefs",
+  "mkdocs-gen-files",
+  "mkdocs-literate-nav",
+  "mkdocs-section-index",
+  "mkdocs-jupyter",
+  "mkdocs-table-reader-plugin",
+  "mkdocs-mermaid2-plugin",
+  "mkdocs-exclude",
+  # markdown extensions used by mkdocs.yml
+  "python-markdown-math",
+  "pymdown-extensions",
+  # API reference generation
+  "mkdocstrings",
+  "mkdocstrings-python",
+  # needed for notebook execution during docs build (plots);
+  # runtime deps (numpy, scipy, pandas, laser-core) are already in
+  # the main `dependencies` list and don't need duplicating here.
+  "matplotlib",
+]
+
 # uv uses this in addition (?) to [project.optional-dependencies] above
 [dependency-groups]
 dev = [

--- a/tox.ini
+++ b/tox.ini
@@ -58,8 +58,10 @@ commands =
 
 [testenv:docs]
 usedevelop = true
-deps =
-    -r{toxinidir}/docs/requirements.txt
+extras =
+    docs
+setenv =
+    PIP_INDEX_URL=https://packages.idmod.org/artifactory/api/pypi/pypi-production/simple
 commands =
     mkdocs build
 


### PR DESCRIPTION
… (#180)

Brings laser-generic in line with peer projects (laser-core, laser-measles), which already expose docs deps as a [project.optional-dependencies] extra.

Changes:
- pyproject.toml: add `docs` extra containing the 14 mkdocs-ecosystem packages from the old requirements.txt, plus `matplotlib` (needed for notebook execution during docs build; not otherwise a runtime dep). Runtime deps (numpy, scipy, pandas, laser-core) are not duplicated because they're already in the main `dependencies` list.
- Three workflows (mkdocs-ghp.yml, mkdocs-pr.yml, release-publish.yml): replace the three-line `pip install -e .` + `pip install mkdocs ...`
  + `pip install -r docs/requirements.txt` block with a single `pip install --index-url <IDM Artifactory> -e ".[docs]"`. The IDM index URL is preserved from the requirements.txt header (--index-url, not --extra-index-url, since the original file made IDM the sole source).
- docs/requirements.txt: deleted.

CHANGELOG.md still mentions docs/requirements.txt in a historical entry; that's intentional — historical changelog entries stay accurate to what shipped at the time.