### PR TITLE
fix: replace old immunization components with Ex versions (closes #195)

### DIFF
--- a/src/laser/generic/__init__.py
+++ b/src/laser/generic/__init__.py
@@ -1,7 +1,7 @@
 __version__ = "1.1.0"
 
-from laser.generic.immunization import ImmunizationCampaign
-from laser.generic.immunization import RoutineImmunization
+from laser.generic.immunization import ImmunizationCampaignEx as ImmunizationCampaign
+from laser.generic.immunization import RoutineImmunizationEx as RoutineImmunization
 from laser.generic.importation import Infect_Random_Agents
 from laser.generic.model import Model
 from laser.generic.shared import State


### PR DESCRIPTION
## What
RoutineImmunization and ImmunizationCampaign used an outdated `__call__(self, model, tick)` interface and relied on old `susceptibility` array assumptions, breaking the `Model.run()` component loop that expects `step(self, tick)`.

## Fix
Replaced the old classes with `RoutineImmunizationEx` and `ImmunizationCampaignEx` which implement `step(self, tick)` and work with `people.state` / `nodes.S` arrays as required by the latest API.

Closes #195