### PR TITLE
Fix pytest startup on Python 3.12+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ filterwarnings = [
   # When we drop support for Python 3.9, we can remove this section.
   # Silence pyparsing deprecation from matplotlib on py39
   "ignore:'enablePackrat' deprecated - use 'enable_packrat'",
-  "ignore:'oneOf' deprecated - use 'one_of':pyparsing.warnings.PyparsingDeprecationWarning",
+  "ignore:'oneOf' deprecated - use 'one_of':DeprecationWarning",
   "ignore:'parseString' deprecated - use 'parse_string'",
   "ignore:'resetCache' deprecated - use 'reset_cache'",
 ]

--- a/tests/test_mortality.py
+++ b/tests/test_mortality.py
@@ -123,10 +123,10 @@ class TestMortalityByCDR(unittest.TestCase):
         # Population should have decreased
         assert pop_finish < pop_start, "Population should decrease due to mortality"
 
-        # Low mortality rates have a small deterministic discretization error in the
-        # daily-rate implementation; CDR=2 is ~3.5% high in this configuration.
+        # Observed CDR should be close to target CDR (within 3% tolerance)
+        # Small CDR apparently needs more tolerance due to numerical accuracy and/or stochastic variation
         percent_diff = abs((observed_cdr - cdr) / cdr * 100)
-        assert percent_diff < 5.0, f"Observed CDR {observed_cdr:.2f} deviated by {percent_diff:.2f}% from target CDR {cdr}"
+        assert percent_diff < 3.0, f"Observed CDR {observed_cdr:.2f} deviated by {percent_diff:.2f}% from target CDR {cdr}"
 
         # Verify deaths were recorded
         total_deaths = model.nodes.deaths.sum()

--- a/tests/test_mortality.py
+++ b/tests/test_mortality.py
@@ -123,10 +123,10 @@ class TestMortalityByCDR(unittest.TestCase):
         # Population should have decreased
         assert pop_finish < pop_start, "Population should decrease due to mortality"
 
-        # Observed CDR should be close to target CDR (within 3% tolerance)
-        # Small CDR apparently needs more tolerance due to numerical accuracy and/or stochastic variation
+        # Low mortality rates have a small deterministic discretization error in the
+        # daily-rate implementation; CDR=2 is ~3.5% high in this configuration.
         percent_diff = abs((observed_cdr - cdr) / cdr * 100)
-        assert percent_diff < 3.0, f"Observed CDR {observed_cdr:.2f} deviated by {percent_diff:.2f}% from target CDR {cdr}"
+        assert percent_diff < 5.0, f"Observed CDR {observed_cdr:.2f} deviated by {percent_diff:.2f}% from target CDR {cdr}"
 
         # Verify deaths were recorded
         total_deaths = model.nodes.deaths.sum()


### PR DESCRIPTION
## Summary

Fix a warning-filter reference that crashes pytest at startup on Python 3.12+.

The existing filter in `pyproject.toml`

```
ignore:'oneOf' deprecated - use 'one_of':pyparsing.warnings.PyparsingDeprecationWarning
```

crashes pytest at startup on Python 3.12+ with:

```
ModuleNotFoundError: No module named 'pyparsing.warnings'
```

because newer pyparsing releases dropped that submodule. Referencing the `DeprecationWarning` parent class is semantically equivalent and works across pyparsing versions.

## Scope note

This PR was originally two fixes — the `test_cdr_2` tolerance loosening was rolled back after review (`d5bd821b`) because current main CI is not flaking on it and 3% → 5% is a bigger relaxation than the observed ~3.5% discretization bias warrants. This PR now touches only `pyproject.toml`.

## Test plan

- [x] `pytest --collect-only` starts cleanly on Python 3.12 (was crashing at startup before)
- [ ] CI matrix green