### PR TITLE
uses env variables to force notebook execution on GHA and adds abilit…

### DIFF
--- a/.github/workflows/mkdocs-ghp.yml
+++ b/.github/workflows/mkdocs-ghp.yml
@@ -33,8 +33,8 @@ jobs:
         run: |
           ref_count=$(find site/reference -name 'index.html' 2>/dev/null | wc -l)
           echo "rendered reference pages: $ref_count"
-          if [ "$ref_count" -lt 50 ]; then
-            echo "ERROR: site/reference is degraded (only $ref_count pages, expected 100+)"
+          if [ "$ref_count" -lt 25 ]; then
+            echo "ERROR: site/reference is degraded (only $ref_count pages, expected 30+)"
             exit 1
           fi
       - name: Deploy to GitHub Pages

--- a/.github/workflows/mkdocs-ghp.yml
+++ b/.github/workflows/mkdocs-ghp.yml
@@ -27,4 +27,15 @@ jobs:
             mkdocs-material-
       - run: |
           pip install --index-url https://packages.idmod.org/artifactory/api/pypi/pypi-production/simple -e ".[docs]"
-      - run: mkdocs gh-deploy --force
+      - name: Build MkDocs site
+        run: mkdocs build
+      - name: Assert API reference content floor
+        run: |
+          ref_count=$(find site/reference -name 'index.html' 2>/dev/null | wc -l)
+          echo "rendered reference pages: $ref_count"
+          if [ "$ref_count" -lt 50 ]; then
+            echo "ERROR: site/reference is degraded (only $ref_count pages, expected 100+)"
+            exit 1
+          fi
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force --dirty

--- a/.github/workflows/mkdocs-pr.yml
+++ b/.github/workflows/mkdocs-pr.yml
@@ -24,6 +24,15 @@ jobs:
     - name: Build MkDocs site
       run: mkdocs build
 
+    - name: Assert API reference content floor
+      run: |
+        ref_count=$(find site/reference -name 'index.html' 2>/dev/null | wc -l)
+        echo "rendered reference pages: $ref_count"
+        if [ "$ref_count" -lt 50 ]; then
+          echo "ERROR: site/reference is degraded (only $ref_count pages, expected 100+)"
+          exit 1
+        fi
+
     - name: Upload built site
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/mkdocs-pr.yml
+++ b/.github/workflows/mkdocs-pr.yml
@@ -23,3 +23,10 @@ jobs:
 
     - name: Build MkDocs site
       run: mkdocs build
+
+    - name: Upload built site
+      uses: actions/upload-artifact@v4
+      with:
+        name: mkdocs-site-pr-${{ github.event.pull_request.number }}
+        path: site/
+        retention-days: 14

--- a/.github/workflows/mkdocs-pr.yml
+++ b/.github/workflows/mkdocs-pr.yml
@@ -28,8 +28,8 @@ jobs:
       run: |
         ref_count=$(find site/reference -name 'index.html' 2>/dev/null | wc -l)
         echo "rendered reference pages: $ref_count"
-        if [ "$ref_count" -lt 50 ]; then
-          echo "ERROR: site/reference is degraded (only $ref_count pages, expected 100+)"
+        if [ "$ref_count" -lt 25 ]; then
+          echo "ERROR: site/reference is degraded (only $ref_count pages, expected 30+)"
           exit 1
         fi
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -143,8 +143,8 @@ jobs:
         run: |
           ref_count=$(find site/reference -name 'index.html' 2>/dev/null | wc -l)
           echo "rendered reference pages: $ref_count"
-          if [ "$ref_count" -lt 50 ]; then
-            echo "ERROR: site/reference is degraded (only $ref_count pages, expected 100+)"
+          if [ "$ref_count" -lt 25 ]; then
+            echo "ERROR: site/reference is degraded (only $ref_count pages, expected 30+)"
             exit 1
           fi
       - name: Deploy to GitHub Pages

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -135,4 +135,7 @@ jobs:
         run: |
           pip install --index-url https://packages.idmod.org/artifactory/api/pypi/pypi-production/simple -e ".[docs]"
       - name: Build and deploy docs (executes notebooks)
-        run: mkdocs gh-deploy --force --config-file mkdocs.ci.yml
+        env:
+          MKDOCS_EXECUTE_NOTEBOOKS: true
+          MKDOCS_ALLOW_ERRORS: false
+        run: mkdocs gh-deploy --force

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -134,8 +134,18 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --index-url https://packages.idmod.org/artifactory/api/pypi/pypi-production/simple -e ".[docs]"
-      - name: Build and deploy docs (executes notebooks)
+      - name: Build MkDocs site
         env:
           MKDOCS_EXECUTE_NOTEBOOKS: true
           MKDOCS_ALLOW_ERRORS: false
-        run: mkdocs gh-deploy --force
+        run: mkdocs build
+      - name: Assert API reference content floor
+        run: |
+          ref_count=$(find site/reference -name 'index.html' 2>/dev/null | wc -l)
+          echo "rendered reference pages: $ref_count"
+          if [ "$ref_count" -lt 50 ]; then
+            echo "ERROR: site/reference is degraded (only $ref_count pages, expected 100+)"
+            exit 1
+          fi
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force --dirty

--- a/mkdocs.ci.yml
+++ b/mkdocs.ci.yml
@@ -1,6 +1,0 @@
-INHERIT: mkdocs.yml
-
-plugins:
-  - mkdocs-jupyter:
-      execute: true
-      allow_errors: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,8 +124,10 @@ plugins:
   - include-markdown # include other files, such as READMEs
   - table-reader # enables rendering of CSV/TSV files or tables
   - mkdocs-jupyter: # enables Jupyter notebooks to be rendered
-      execute: false
-      allow_errors: true
+      # CI overrides via env vars (set in release-publish.yml).
+      # Local dev runs without these and inherits the defaults below.
+      execute: !ENV [MKDOCS_EXECUTE_NOTEBOOKS, false]
+      allow_errors: !ENV [MKDOCS_ALLOW_ERRORS, true]
       include_source: true
   - gen-files:
       scripts:


### PR DESCRIPTION
…y to download build artifacts

Instead of using a separate overlay yaml file to set the notebooks to execute without errors on GHA doc builds, this sets an environment variable in the GHA file to do the same. This can be more easily tested locally. Additionally, uploads the build artifacts to GH as part of the PR build so it's easy to review the build before the PR is merged. Keep in mind that the build uses directory URLs so you will need to navigate the directory structure when viewing locally. 