### PR TITLE
concat_mkdocs: handle !ENV YAML tag (fixes #223)

### DIFF
--- a/docs/concat_mkdocs.py
+++ b/docs/concat_mkdocs.py
@@ -61,6 +61,26 @@ def _python_name_placeholder(loader, suffix, node):
 _NavLoader.add_multi_constructor("tag:yaml.org,2002:python/name:", _python_name_placeholder)
 
 
+def _env_placeholder(loader, node):
+    """Handle mkdocs' ``!ENV [VAR_NAME, default]`` env-var directive.
+
+    PR #220 introduced ``!ENV`` in mkdocs.yml to toggle notebook execution
+    between local and CI builds. That tag is MkDocs-specific; plain PyYAML
+    (which this loader is built on) doesn't know it and aborts the whole
+    parse with a ConstructorError. Return the declared default (last element
+    of the sequence) so the file parses; nothing downstream in
+    concat_mkdocs.py consumes the value — it only walks ``nav:`` for
+    string paths.
+    """
+    if isinstance(node, yaml.SequenceNode):
+        seq = loader.construct_sequence(node)
+        return seq[-1] if seq else ""
+    return ""
+
+
+_NavLoader.add_constructor("!ENV", _env_placeholder)
+
+
 def extract_markdown(html_path: Path) -> str:
     """Pull the main article from a MkDocs HTML page and convert it back to markdown."""
     text = html_path.read_text(encoding="utf-8", errors="replace")

--- a/docs/concat_mkdocs.py
+++ b/docs/concat_mkdocs.py
@@ -74,7 +74,7 @@ def _env_placeholder(loader, node):
     """
     if isinstance(node, yaml.SequenceNode):
         seq = loader.construct_sequence(node)
-        return seq[-1] if seq else ""
+        return seq[-1] if len(seq) >= 2 else ""
     return ""
 
 


### PR DESCRIPTION
## Summary

Fixes #223. **Also unblocks the `Build Combined Doc` GHA workflow, which has been failing on every run since [PR #220](https://github.com/laser-base/laser-generic/pull/220) merged 2026-06-30** — no successful artifact has been produced since that date.

PR #220 introduced `!ENV` directives in `mkdocs.yml` for toggling `mkdocs-jupyter` notebook execution between local and CI builds:

```yaml
  - mkdocs-jupyter:
      execute: !ENV [MKDOCS_EXECUTE_NOTEBOOKS, false]
      allow_errors: !ENV [MKDOCS_ALLOW_ERRORS, true]
```

The `mkdocs` CLI understands `!ENV`, so the `mkdocs build` step inside the workflow succeeds. But the workflow ALSO runs `docs/concat_mkdocs.py` as a separate script step afterward, and that script opens `mkdocs.yml` independently through PyYAML's `SafeLoader` (subclassed as `_NavLoader`). `SafeLoader` doesn't know `!ENV` and aborts:

```
python docs/concat_mkdocs.py site dist/executed_nbs dist/combined_mkdocs.md
  ...
  File "docs/concat_mkdocs.py", line 307, in concat
    raise ConstructorError(...)
yaml.constructor.ConstructorError: could not determine a constructor for the tag '!ENV'
  in "mkdocs.yml", line 129, column 16
make: *** [Makefile:77: docs-jenner] Error 1
```

Verified in workflow run [28481556716](https://github.com/laser-base/laser-generic/actions/runs/28481556716) (2026-06-30 23:04) — the notebooks executed cleanly, `mkdocs build` succeeded, then concat crashed on `!ENV`. Same failure would recur on every subsequent triggered run of the workflow. This isn't only a local-build annoyance; the workflow's whole reason for existing (producing `dist/combined_mkdocs.md` as an uploaded artifact + auto-PR into laser-mcp) is currently non-functional.

## Fix

Register a small custom constructor on `_NavLoader` for `!ENV` that returns the declared default (the last element of the `[VAR_NAME, default]` sequence). Enough for parsing to succeed; nothing downstream in `concat_mkdocs.py` consumes the resolved value — the script only walks `nav:` for string paths.

Returning the default (rather than the env-var name) is a small nicety that mirrors what MkDocs does when the env var isn't set.

## Verification

Local smoke test:

```python
import yaml, sys; sys.path.insert(0, 'docs')
from concat_mkdocs import _NavLoader
c = yaml.load(open('mkdocs.yml'), Loader=_NavLoader)
# execute      → False   (from `false` default)
# allow_errors → True    (from `true` default)
```

## Test plan

- [x] `mkdocs.yml` parses via `_NavLoader` without ConstructorError
- [x] Defaults resolve correctly (`False` / `True`)
- [ ] Trigger `Build Combined Doc` on this branch once CI is happy — should produce a `dist/combined_mkdocs.md` artifact for the first time since PR #220 merged.

## Discovery context

Surfaced while running the laser-mcp `jenner-generic-mcp` test suite locally against a rebuilt `laser-generic.md`. Documented empirically in [laser-mcp PR #33 comment](https://github.com/InstituteforDiseaseModeling/laser-mcp/pull/33#issuecomment-4857420865): refreshing `laser-generic.md` from post-#212 main takes the suite from 15/21 (never=6) to 20/21 (never=1), so this fix is on the critical path for anyone (local or CI) trying to rebuild the doc corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)