### PR TITLE
ci: path-gate mkdocs-pr.yml to skip docs build on unrelated PRs

### DIFF
--- a/.github/workflows/mkdocs-pr.yml
+++ b/.github/workflows/mkdocs-pr.yml
@@ -3,6 +3,16 @@ name: MkDocs Build on PR
 on:
   pull_request:
     branches: [ master, main ]  # Replace with your desired branches
+    # Only run the docs build (which executes notebooks in CI via
+    # MKDOCS_EXECUTE_NOTEBOOKS=true) when a PR touches something that can
+    # affect the built docs. PRs that only touch tests, other CI, README,
+    # or unrelated files skip the ~15-minute notebook-execution job.
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'pyproject.toml'
+      - 'src/**'
+      - '.github/workflows/mkdocs-pr.yml'
 
 jobs:
   build:

--- a/.github/workflows/mkdocs-pr.yml
+++ b/.github/workflows/mkdocs-pr.yml
@@ -3,10 +3,10 @@ name: MkDocs Build on PR
 on:
   pull_request:
     branches: [ master, main ]  # Replace with your desired branches
-    # Only run the docs build (which executes notebooks in CI via
+    # Only run the docs build (which can execute notebooks when
     # MKDOCS_EXECUTE_NOTEBOOKS=true) when a PR touches something that can
     # affect the built docs. PRs that only touch tests, other CI, README,
-    # or unrelated files skip the ~15-minute notebook-execution job.
+    # or unrelated files skip the docs-build job.
     paths:
       - 'docs/**'
       - 'mkdocs.yml'


### PR DESCRIPTION
## Summary

Adds an `on.pull_request.paths:` filter to `mkdocs-pr.yml` so the docs-build workflow (which executes notebooks under `MKDOCS_EXECUTE_NOTEBOOKS=true` in CI, wired up in #220) only runs when a PR touches something that could affect the built docs. PRs that only change tests, other CI, README, or unrelated files skip the ~15-minute notebook-execution job.

Gated paths:
- `docs/**` — anything under docs (notebooks, markdown pages, gen-files scripts, custom CSS)
- `mkdocs.yml` — config that drives the build
- `pyproject.toml` — the `[docs]` extra installed by the workflow
- `src/**` — package code that notebooks import from
- `.github/workflows/mkdocs-pr.yml` — the workflow itself (so edits self-test)

## Motivation

Follow-up to #189 (closed as superseded by #220). #189 tried to solve two things at once — add notebook execution *and* add path-gating — via a workflow-replacement approach that no longer applies now that #220 solved execution differently. This PR is just the path-gating piece, as a minimal surgical change to the current workflow.

Concrete example: PR #208 (a 1-line `pyproject.toml` fix) still paid the full docs-build cost. Under this filter, it would too — because `pyproject.toml` is in the gate — which is correct (deps affect the [docs] extra install). But a PR that only touches `tests/**` or `.github/workflows/build-combined-doc.yml` would now skip the docs build.

## Caveat if `build` is a required status check

`on.pull_request.paths:` prevents the workflow from running at all when the filter doesn't match, which means the `build` status won't be reported on those PRs. If GitHub branch protection requires `build` before merge, PRs that don't touch gated paths would be blocked forever. If that turns out to be the case, we'd need to swap this for a two-job pattern (a cheap gatekeeper job that always runs + a heavy job that conditionally does work) — but that's noticeably more complex, so trying the simple form first.

## Test plan

- [ ] CI runs on this PR itself (it touches `.github/workflows/mkdocs-pr.yml`, so it should hit the gate)
- [ ] Confirm `build` reports SUCCESS
- [ ] Optionally: land, then verify that a subsequent tests-only PR skips the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)