### PR TITLE
Add concurrency group to gh-pages deploy workflow

### DIFF
--- a/.github/workflows/mkdocs-ghp.yml
+++ b/.github/workflows/mkdocs-ghp.yml
@@ -6,6 +6,9 @@ on:
       - main
 permissions:
   contents: write
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: true
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Overlapping mkdocs-ghp.yml runs from closely-spaced merges to main each force-push to gh-pages, which races GitHub's Pages deployment and causes it to cancel the earlier deployment. Serialize (and cancel superseded) runs so only the latest deploy proceeds.

The alternative solution is just to tolerate this edge case (only happens when PRs are merged within 3 minutes of one another) and manually re-trigger the failed action. 