### PR TITLE
Re-export get_default_parameters at laser.generic top level

### DIFF
--- a/src/laser/generic/__init__.py
+++ b/src/laser/generic/__init__.py
@@ -5,6 +5,7 @@ from laser.generic.immunization import RoutineImmunization
 from laser.generic.importation import Infect_Random_Agents
 from laser.generic.model import Model
 from laser.generic.shared import State
+from laser.generic.utils import get_default_parameters
 
 from . import SEIR
 from . import SEIRS
@@ -25,4 +26,5 @@ __all__ = [
     "Model",
     "RoutineImmunization",
     "State",
+    "get_default_parameters",
 ]


### PR DESCRIPTION
## Summary

`get_default_parameters` lives at `laser.generic.utils.get_default_parameters`, but LLM-generated laser-generic code (from the `jenner-generic-mcp` RAG server) consistently mis-imports it as `from laser.generic import get_default_parameters`. That mis-import currently kills **7 of 21 prompts** in the alpha test suite (p02, p03, p05, p15, p20, p21, p16) — every one of them hits an `ImportError: cannot import name 'get_default_parameters' from 'laser.generic'` on iter1 and never recovers within the 3-iteration retry cap.

The mis-import isn't the model being dumb — it's a reasonable generalization. The doc has 19+ examples of `from laser.generic import <TopLevelExport>` (Model, SIR, SEIR, State, SI, etc.) against a single `from laser.generic.utils import get_default_parameters` example. RAG top-K retrieval on a large corpus doesn't reliably surface that single example.

Adding `get_default_parameters` to the top-level namespace makes both import paths work, so both the LLM's natural guess and the fully-qualified path from the docs succeed. Backward-compatible for existing callers using the fully-qualified import.

## Test plan

- [x] Both import paths work: `from laser.generic import get_default_parameters` and `from laser.generic.utils import get_default_parameters`
- [ ] Re-run the alpha suite against post-merge main — expect p02, p03, p05, p15, p16, p20, p21 to pass, recovering from 13/21 → 20/21 (matching the pre-#204 baseline). p07 is a separate scenario-dict-vs-PropertySet issue that this change doesn't touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)