### PR TITLE
concat_mkdocs: demote notebook headings + warn on oversize sections (RAG-quality)

### DIFF
--- a/docs/concat_mkdocs.py
+++ b/docs/concat_mkdocs.py
@@ -351,7 +351,7 @@ def _warn_oversized_sections(combined: str) -> int:
     """Report H2+ sections that exceed the soft cap, with source-file provenance.
 
     Downstream (see laser-mcp/ingest.py) uses MarkdownHeaderTextSplitter on
-    H1/H2/H3/H4 then a 1200-char character splitter for anything still too big.
+    H1/H2/H3, then a 1200-char character splitter for anything still too big.
     Once a section is much larger than a few chunks the character splitter
     falls through its code-block-aware separators to line-level splits — which
     tear fenced code examples across chunks and hurt retrieval quality. Warn

--- a/docs/concat_mkdocs.py
+++ b/docs/concat_mkdocs.py
@@ -238,7 +238,33 @@ def notebook_to_markdown(nb_path: Path) -> str:
                 parts.append(f"```\n{body}\n```")
 
     md = "\n\n".join(parts)
-    return re.sub(r"\n{3,}", "\n\n", md).strip()
+    md = re.sub(r"\n{3,}", "\n\n", md).strip()
+
+    # Demote all headings by one level so:
+    #   - notebook titles (originally H1) become H2, sitting cleanly under the
+    #     combined doc's single H1 ("# laser-generic documentation"),
+    #   - notebook subsections (originally H2 like "## Larger test suite")
+    #     become H3, which the RAG header-splitter catches structurally,
+    #   - nested notebook sections stay proportionally deeper.
+    # Levels are clamped at H6 (Markdown's max) to avoid emitting invalid H7+.
+    #
+    # CRITICAL: skip lines inside fenced code blocks — Python comments like
+    # ``# %%capture`` or ``# TODO`` would otherwise be misread as headings and
+    # demoted, corrupting the code AND emitting bogus H2 section boundaries.
+    out_lines = []
+    in_fence = False
+    for line in md.split("\n"):
+        stripped = line.lstrip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            out_lines.append(line)
+            continue
+        if not in_fence:
+            m = re.match(r"^(#{1,5})(?= )", line)
+            if m:
+                line = "#" * (len(m.group(1)) + 1) + line[len(m.group(1)):]
+        out_lines.append(line)
+    return "\n".join(out_lines)
 
 
 def iter_nav_pages(nav):
@@ -301,6 +327,44 @@ def append_section(parts: list, source, md: str, url: str = "") -> bool:
         provenance += f" · [View page online]({url})"
     parts.append(f"\n\n---\n\n{provenance}\n\n{md}")
     return True
+
+
+# Soft cap for section size beyond which the RAG chunker starts making lossy
+# splits (fracturing fenced code examples across chunks). Not a hard error —
+# just a warning that surfaces which content needs subheadings or cell splits.
+_SECTION_SOFT_MAX = 5000
+
+
+def _warn_oversized_sections(combined: str) -> int:
+    """Report H2+ sections that exceed the soft cap.
+
+    Downstream (see laser-mcp/ingest.py) uses MarkdownHeaderTextSplitter on
+    H1/H2/H3/H4 then a 1200-char character splitter for anything still too big.
+    Once a section is much larger than a few chunks the character splitter
+    falls through its code-block-aware separators to line-level splits — which
+    tear fenced code examples across chunks and hurt retrieval quality. Warn
+    so authors can add subheadings (H3/H4/H5) or split the underlying notebook
+    cells into smaller logical sections.
+    """
+    positions = [(m.start(), m.group(0).strip())
+                 for m in re.finditer(r"^##+ [^\n]+", combined, re.MULTILINE)]
+    positions.append((len(combined), None))
+    warnings = []
+    for (start, heading), (end, _) in zip(positions[:-1], positions[1:]):
+        size = end - start
+        if size > _SECTION_SOFT_MAX:
+            warnings.append((size, heading))
+    if warnings:
+        warnings.sort(reverse=True)
+        print(f"\n  WARNING: {len(warnings)} section(s) exceed {_SECTION_SOFT_MAX:,} chars "
+              f"(RAG chunking may fracture code examples):")
+        for size, heading in warnings[:15]:
+            print(f"    {size:>7,} chars  {heading[:80]}")
+        if len(warnings) > 15:
+            print(f"    ...{len(warnings) - 15} more")
+        print(f"  Add subheadings (H3/H4/H5) or split cells so no section exceeds "
+              f"{_SECTION_SOFT_MAX:,} chars.")
+    return len(warnings)
 
 
 def _is_reference_entry(entry: str) -> bool:
@@ -413,9 +477,12 @@ def concat(mkdocs_dir: str, notebooks_dir: str, output_file: str):
     if nb_included == 0:
         print("WARNING: 0 notebook pages included — were notebooks executed into the dir?")
 
+    combined = "\n".join(parts)
+    _warn_oversized_sections(combined)
+
     output = Path(output_file)
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text("\n".join(parts), encoding="utf-8")
+    output.write_text(combined, encoding="utf-8")
 
     total = main_included + nb_included + ref_included
     print(f"\nWrote {total} sections ({skipped} skipped) -> {output_file}")

--- a/docs/concat_mkdocs.py
+++ b/docs/concat_mkdocs.py
@@ -335,8 +335,20 @@ def append_section(parts: list, source, md: str, url: str = "") -> bool:
 _SECTION_SOFT_MAX = 5000
 
 
+def _find_source_before(combined: str, pos: int) -> str:
+    """Walk backward from ``pos`` to the nearest ``**Source:** `<path>`
+    breadcrumb (emitted by :func:`append_section`) and return that path.
+    Returns ``"?"`` if no breadcrumb is found — shouldn't happen given
+    every section is prefixed with one, but degrade gracefully.
+    """
+    m = None
+    for candidate in re.finditer(r"\*\*Source:\*\* `([^`]+)`", combined[:pos]):
+        m = candidate
+    return m.group(1) if m else "?"
+
+
 def _warn_oversized_sections(combined: str) -> int:
-    """Report H2+ sections that exceed the soft cap.
+    """Report H2+ sections that exceed the soft cap, with source-file provenance.
 
     Downstream (see laser-mcp/ingest.py) uses MarkdownHeaderTextSplitter on
     H1/H2/H3/H4 then a 1200-char character splitter for anything still too big.
@@ -345,6 +357,11 @@ def _warn_oversized_sections(combined: str) -> int:
     tear fenced code examples across chunks and hurt retrieval quality. Warn
     so authors can add subheadings (H3/H4/H5) or split the underlying notebook
     cells into smaller logical sections.
+
+    Each warning line names the source file (notebook or .md) that contributed
+    the section, resolved via the ``**Source:**`` breadcrumbs that
+    :func:`append_section` emits — so authors can go straight to the file
+    that needs subheadings without grepping.
     """
     positions = [(m.start(), m.group(0).strip()) for m in re.finditer(r"^##+ [^\n]+", combined, re.MULTILINE)]
     positions.append((len(combined), None))
@@ -352,12 +369,13 @@ def _warn_oversized_sections(combined: str) -> int:
     for (start, heading), (end, _) in zip(positions[:-1], positions[1:]):
         size = end - start
         if size > _SECTION_SOFT_MAX:
-            warnings.append((size, heading))
+            source = _find_source_before(combined, start)
+            warnings.append((size, heading, source))
     if warnings:
         warnings.sort(reverse=True)
         print(f"\n  WARNING: {len(warnings)} section(s) exceed {_SECTION_SOFT_MAX:,} chars (RAG chunking may fracture code examples):")
-        for size, heading in warnings[:15]:
-            print(f"    {size:>7,} chars  {heading[:80]}")
+        for size, heading, source in warnings[:15]:
+            print(f"    {size:>7,} chars  {heading[:60]:60}  {source}")
         if len(warnings) > 15:
             print(f"    ...{len(warnings) - 15} more")
         print(f"  Add subheadings (H3/H4/H5) or split cells so no section exceeds {_SECTION_SOFT_MAX:,} chars.")

--- a/docs/concat_mkdocs.py
+++ b/docs/concat_mkdocs.py
@@ -262,7 +262,7 @@ def notebook_to_markdown(nb_path: Path) -> str:
         if not in_fence:
             m = re.match(r"^(#{1,5})(?= )", line)
             if m:
-                line = "#" * (len(m.group(1)) + 1) + line[len(m.group(1)):]
+                line = "#" * (len(m.group(1)) + 1) + line[len(m.group(1)) :]
         out_lines.append(line)
     return "\n".join(out_lines)
 

--- a/docs/concat_mkdocs.py
+++ b/docs/concat_mkdocs.py
@@ -346,8 +346,7 @@ def _warn_oversized_sections(combined: str) -> int:
     so authors can add subheadings (H3/H4/H5) or split the underlying notebook
     cells into smaller logical sections.
     """
-    positions = [(m.start(), m.group(0).strip())
-                 for m in re.finditer(r"^##+ [^\n]+", combined, re.MULTILINE)]
+    positions = [(m.start(), m.group(0).strip()) for m in re.finditer(r"^##+ [^\n]+", combined, re.MULTILINE)]
     positions.append((len(combined), None))
     warnings = []
     for (start, heading), (end, _) in zip(positions[:-1], positions[1:]):
@@ -356,14 +355,12 @@ def _warn_oversized_sections(combined: str) -> int:
             warnings.append((size, heading))
     if warnings:
         warnings.sort(reverse=True)
-        print(f"\n  WARNING: {len(warnings)} section(s) exceed {_SECTION_SOFT_MAX:,} chars "
-              f"(RAG chunking may fracture code examples):")
+        print(f"\n  WARNING: {len(warnings)} section(s) exceed {_SECTION_SOFT_MAX:,} chars (RAG chunking may fracture code examples):")
         for size, heading in warnings[:15]:
             print(f"    {size:>7,} chars  {heading[:80]}")
         if len(warnings) > 15:
             print(f"    ...{len(warnings) - 15} more")
-        print(f"  Add subheadings (H3/H4/H5) or split cells so no section exceeds "
-              f"{_SECTION_SOFT_MAX:,} chars.")
+        print(f"  Add subheadings (H3/H4/H5) or split cells so no section exceeds {_SECTION_SOFT_MAX:,} chars.")
     return len(warnings)
 
 


### PR DESCRIPTION
Two RAG-quality improvements to `docs/concat_mkdocs.py`.

## Motivation

The RAG pipeline downstream (`laser-mcp/ingest.py`) chunks the combined markdown structurally with `MarkdownHeaderTextSplitter` on H1-H3, then falls back to a 1200-char `RecursiveCharacterTextSplitter` for anything still oversize. When a section is much larger than a few chunks, the character splitter runs out of code-block-aware separators and starts tearing fenced code examples at line boundaries — the LLM sees `parameters = Pro...` where the truncated word breaks retrieval-adjacent context. Retrieval quality suffers.

Analysis of the pre-fix combined doc showed **45% of H1-H3 sections exceeded 1200 chars**, with a handful in the 100K-459K char range — essentially entire notebooks stuffed under one H2 heading because those notebooks lack internal H3/H4 subsections.

## Changes

**1. Demote notebook headings by one level** in `notebook_to_markdown`.
Notebook titles (originally H1) become H2, sitting cleanly under the combined doc's single H1 (`# laser-generic documentation`). Notebook sub-sections (originally H2, e.g. `## Larger test suite`) become H3, which the RAG header-splitter catches structurally instead of handing to the character splitter mid-code. Deeper subsections stay proportionally deeper, clamped at H6 to avoid emitting invalid H7+.

Critically, the demote skips lines inside fenced code blocks — Python comments like `# %%capture` or `# TODO` would otherwise be misread as headings and demoted, corrupting the code AND emitting bogus H2 section boundaries.

**2. Warn on oversized sections** via new `_warn_oversized_sections()`.
After writing the combined doc, scan H2+ sections and print a warning listing any that exceed 5000 chars (soft cap). Non-blocking — surfaces which specific sections need author attention (add H3/H4/H5, or split cells) without failing the build.

## Verified locally

Applied to a locally-built combined doc:
- Previously-mega `## Larger test suite` (~459K chars of interleaved code + tqdm output) drops to a splittable ~14K chars after the demote + #229's broadened tqdm strip.
- The warning cleanly lists 26 remaining oversize sections for future author cleanup.

End-to-end jenner-generic-mcp alpha suite (yechen's stripped server, this corpus, #228's runtime fix in place):
- **18/21 pass, 8 a1** on this test — up from **5 a1** on the same server config with the unmodified corpus.
- The dict-as-params `AttributeError: 'dict' object has no attribute 'nticks'` failure class — 9 prompts previously — is entirely gone from iter1.

## Coordination

Depends on: nothing (mergeable independently).
Complementary with: #229 (tqdm-strip broadening). The two together produce the full retrieval-quality gain, but they're orthogonal — merge order doesn't matter.
Companion: a small `laser-mcp/ingest.py` change (add H4 to the header splitter, so the newly-demoted H4 sections are also caught structurally) will ship as a separate laser-mcp PR.