### PR TITLE
ci: split notebook execution into its own workflow with cached artifact (closes #186)

### DIFF
--- a/.github/workflows/build-combined-doc.yml
+++ b/.github/workflows/build-combined-doc.yml
@@ -3,16 +3,22 @@ name: Build Combined Doc
 # Builds the combined-markdown RAG corpus and syncs it into laser-mcp.
 # Consumes the executed_nbs artifact published by Execute Notebooks — no
 # in-workflow notebook execution. Triggered automatically after each
-# successful Execute Notebooks run on main, or manually via dispatch.
+# successful push-driven Execute Notebooks run on main, or manually via
+# dispatch.
 
 on:
-  # Auto-fire after every successful Execute Notebooks run.
+  # Auto-fire after every successful push-triggered Execute Notebooks run.
   workflow_run:
     workflows: ["Execute Notebooks"]
     types: [completed]
     branches: [main]
   # Manual: pulls the latest successful Execute Notebooks artifact.
   workflow_dispatch:
+    inputs:
+      use_latest_anyway:
+        description: 'On workflow_dispatch, skip the source-hash-vs-checkout compatibility check. Use if you deliberately want to build against a mismatched (older/different) artifact.'
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -21,7 +27,7 @@ jobs:
     # workflow_dispatch runs — a debug dispatch (e.g. allow_notebook_errors=true
     # or force_reexecute=true) would otherwise auto-fire this workflow and
     # push a possibly-corrupted corpus PR into laser-mcp. Manual doc rebuilds
-    # (with the latest known-good artifact) go through this workflow's own
+    # (against the latest known-good artifact) go through this workflow's own
     # workflow_dispatch trigger, which is always allowed.
     if: >-
       github.event_name == 'workflow_dispatch' ||
@@ -66,6 +72,33 @@ jobs:
           path: dist/executed_nbs
           workflow_conclusion: success
           if_no_artifact_found: fail
+
+      # Provenance gate — only meaningful for workflow_dispatch. The
+      # workflow_run path already fetches by explicit run-id, so no drift is
+      # possible there. Compares the artifact's manifest.source_hash to a
+      # freshly-computed hash of the current checkout using the same file set
+      # as execute-notebooks.yml. Bypass with use_latest_anyway=true if you
+      # intentionally want to build against an older artifact.
+      - name: Verify artifact matches checkout (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch' && !inputs.use_latest_anyway
+        run: |
+          CURRENT_HASH="${{ hashFiles(
+            'docs/**/*.ipynb',
+            'src/**/*.py',
+            'pyproject.toml',
+            'docs/requirements.txt',
+            'docs/**/*.py',
+            'Makefile'
+          ) }}"
+          ARTIFACT_HASH=$(python -c "import json; print(json.load(open('dist/executed_nbs/manifest.json'))['source_hash'])")
+          echo "artifact hash: $ARTIFACT_HASH"
+          echo "checkout hash: $CURRENT_HASH"
+          if [ "$ARTIFACT_HASH" != "$CURRENT_HASH" ]; then
+              echo "::error::Artifact source-hash does not match the currently-checked-out tree."
+              echo "::error::The executed notebooks in the latest successful Execute Notebooks run were produced from a different source state than what's checked out here."
+              echo "::error::Kick a fresh Execute Notebooks run, or re-dispatch this workflow with use_latest_anyway=true."
+              exit 1
+          fi
 
       # No re-execution here — Execute Notebooks already produced the executed
       # tree and gated on docs-check-nbs. This step just builds the mkdocs

--- a/.github/workflows/build-combined-doc.yml
+++ b/.github/workflows/build-combined-doc.yml
@@ -16,9 +16,20 @@ on:
 
 jobs:
   build:
-    # Skip if the upstream Execute Notebooks run failed (no artifact worth
-    # consuming). workflow_dispatch triggers pass this check trivially.
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    # Auto-chain from workflow_run is restricted to push-triggered upstream
+    # Execute Notebooks runs. This intentionally excludes upstream
+    # workflow_dispatch runs — a debug dispatch (e.g. allow_notebook_errors=true
+    # or force_reexecute=true) would otherwise auto-fire this workflow and
+    # push a possibly-corrupted corpus PR into laser-mcp. Manual doc rebuilds
+    # (with the latest known-good artifact) go through this workflow's own
+    # workflow_dispatch trigger, which is always allowed.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'workflow_run'
+        && github.event.workflow_run.conclusion == 'success'
+        && github.event.workflow_run.event == 'push'
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0

--- a/.github/workflows/build-combined-doc.yml
+++ b/.github/workflows/build-combined-doc.yml
@@ -88,7 +88,8 @@ jobs:
             'pyproject.toml',
             'docs/requirements.txt',
             'docs/**/*.py',
-            'Makefile'
+            'Makefile',
+            '.github/workflows/execute-notebooks.yml'
           ) }}"
           ARTIFACT_HASH=$(python -c "import json; print(json.load(open('dist/executed_nbs/manifest.json'))['source_hash'])")
           echo "artifact hash: $ARTIFACT_HASH"

--- a/.github/workflows/build-combined-doc.yml
+++ b/.github/workflows/build-combined-doc.yml
@@ -1,19 +1,24 @@
 name: Build Combined Doc
 
+# Builds the combined-markdown RAG corpus and syncs it into laser-mcp.
+# Consumes the executed_nbs artifact published by Execute Notebooks — no
+# in-workflow notebook execution. Triggered automatically after each
+# successful Execute Notebooks run on main, or manually via dispatch.
+
 on:
+  # Auto-fire after every successful Execute Notebooks run.
+  workflow_run:
+    workflows: ["Execute Notebooks"]
+    types: [completed]
+    branches: [main]
+  # Manual: pulls the latest successful Execute Notebooks artifact.
   workflow_dispatch:
-    inputs:
-      allow_notebook_errors:
-        description: 'Publish the combined doc even if notebooks have execution errors (artifact may contain tracebacks).'
-        type: boolean
-        default: false
-      nb_timeout:
-        description: 'Per-cell execution timeout in seconds. Heavy parameter-sweep cells (e.g. nb04, nb05) can exceed the Makefile default of 600. 1800 is a comfortable headroom.'
-        type: string
-        default: '1800'
 
 jobs:
   build:
+    # Skip if the upstream Execute Notebooks run failed (no artifact worth
+    # consuming). workflow_dispatch triggers pass this check trivially.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0
@@ -22,12 +27,43 @@ jobs:
           python-version: '3.12'
       - name: Install dependencies
         run: make docs-install
-      - name: Build combined doc
-        # Translate the workflow_dispatch boolean into the 0/1 the Makefile uses.
-        # nb_timeout is forwarded as NB_TIMEOUT (per-cell timeout, seconds).
-        run: make docs-jenner ALLOW_NB_ERRORS=${{ inputs.allow_notebook_errors && '1' || '0' }} NB_TIMEOUT=${{ inputs.nb_timeout }}
+
+      # Two download paths, one for each trigger. workflow_run passes the
+      # specific upstream run-id so we always fetch the artifact that just
+      # signalled completion. workflow_dispatch has no such linkage and grabs
+      # whatever the most recent successful Execute Notebooks run produced.
+      - name: Download executed notebooks (from triggering run)
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          name: executed_nbs
+          path: dist/executed_nbs
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # dawidd6/action-download-artifact is used here (not actions/download-artifact)
+      # because the first-party action can only fetch from the current run or a
+      # run-id you already know. This one searches for the latest successful run
+      # of a named workflow — which is exactly what workflow_dispatch needs
+      # since there's no "triggering upstream run" to point at.
+      - name: Download executed notebooks (latest successful)
+        if: github.event_name == 'workflow_dispatch'
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          workflow: execute-notebooks.yml
+          name: executed_nbs
+          path: dist/executed_nbs
+          workflow_conclusion: success
+          if_no_artifact_found: fail
+
+      # No re-execution here — Execute Notebooks already produced the executed
+      # tree and gated on docs-check-nbs. This step just builds the mkdocs
+      # site and concats it with the downloaded executed notebooks.
+      - name: Build combined doc from artifact
+        run: make docs-jenner-artifact
+
       - name: Upload combined_mkdocs.md
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@v4
         with:
           name: combined_mkdocs
           path: dist/combined_mkdocs.md

--- a/.github/workflows/execute-notebooks.yml
+++ b/.github/workflows/execute-notebooks.yml
@@ -99,7 +99,8 @@ jobs:
             'pyproject.toml',
             'docs/requirements.txt',
             'docs/**/*.py',
-            'Makefile'
+            'Makefile',
+            '.github/workflows/execute-notebooks.yml'
           ) }}"
           echo "hash=$SOURCE_HASH" >> "$GITHUB_OUTPUT"
           echo "Source hash: $SOURCE_HASH"
@@ -113,7 +114,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: dist/executed_nbs
-          key: executed-nbs-v3-${{ steps.source-hash.outputs.hash }}
+          key: executed-nbs-v4-${{ steps.source-hash.outputs.hash }}
 
       - name: Execute notebooks (cache miss or forced)
         if: ${{ steps.nb-cache.outputs.cache-hit != 'true' || inputs.force_reexecute }}

--- a/.github/workflows/execute-notebooks.yml
+++ b/.github/workflows/execute-notebooks.yml
@@ -27,12 +27,18 @@ name: Execute Notebooks
 on:
   push:
     branches: [main]
+    # Trigger whenever ANY input that could change executed-notebook outputs
+    # changes. Kept in sync with the cache-key hashFiles below — if you add
+    # something here that affects outputs, add it to the cache key too, else
+    # a push could trigger this workflow but hit an old cache entry.
     paths:
-      - 'docs/**/*.ipynb'                       # notebook source changed
-      - 'src/**'                                # library that notebooks import changed
-      - 'pyproject.toml'                        # dependencies changed
-      - 'docs/execute_notebooks.py'             # exec harness itself changed
-      - 'docs/check_executed_nbs.py'            # error gate changed
+      - 'docs/**/*.ipynb'                       # notebook source
+      - 'src/**'                                # library that notebooks import
+      - 'pyproject.toml'                        # runtime dependencies
+      - 'docs/requirements.txt'                 # docs / exec-time dependencies
+      - 'docs/execute_notebooks.py'             # exec harness itself
+      - 'docs/check_executed_nbs.py'            # error gate
+      - 'Makefile'                              # NB_EXCLUDE / NB_TIMEOUT / other exec defaults
       - '.github/workflows/execute-notebooks.yml'
   workflow_dispatch:
     inputs:
@@ -67,16 +73,27 @@ jobs:
         run: make docs-install
 
       # Any change to the hashed inputs busts the cache and forces re-execution.
-      # Bump the key prefix (executed-nbs-vN) to invalidate the whole cache pool
-      # if the executor itself is upgraded in a way we want to redo across all
-      # historic source states.
+      # Files hashed here MUST cover everything that can affect executed
+      # notebook outputs — else a change (e.g. to NB_EXCLUDE in the Makefile,
+      # or a new dep in docs/requirements.txt) would trigger this workflow via
+      # the paths filter above but still hit an old cache entry.
+      # Bump the key prefix (executed-nbs-vN) to invalidate the whole cache
+      # pool if the hashing set itself needs to change historic-state-wide.
       - name: Cache executed notebooks
         id: nb-cache
         if: ${{ !inputs.force_reexecute }}
         uses: actions/cache@v4
         with:
           path: dist/executed_nbs
-          key: executed-nbs-v1-${{ hashFiles('docs/**/*.ipynb', 'src/**/*.py', 'pyproject.toml') }}
+          key: >-
+            executed-nbs-v2-${{ hashFiles(
+              'docs/**/*.ipynb',
+              'src/**/*.py',
+              'pyproject.toml',
+              'docs/requirements.txt',
+              'docs/execute_notebooks.py',
+              'Makefile'
+            ) }}
 
       - name: Execute notebooks (cache miss or forced)
         if: ${{ steps.nb-cache.outputs.cache-hit != 'true' || inputs.force_reexecute }}

--- a/.github/workflows/execute-notebooks.yml
+++ b/.github/workflows/execute-notebooks.yml
@@ -5,10 +5,20 @@ name: Execute Notebooks
 # artifact instead of re-executing notebooks on every doc build.
 #
 # Cache is keyed on a hash of everything that can affect notebook outputs
-# (notebook source, library source, dependencies). Cache hit = seconds;
-# cache miss = full nbconvert --execute pass, currently ~25 min with the
-# env-var-lite path for nb06 (GITHUB_ACTIONS=true triggers the light branch
-# introduced in #233).
+# (notebook source, library source, dependencies, exec harness, Makefile
+# defaults). Cache hit = seconds; cache miss = full nbconvert --execute pass,
+# currently ~25 min with the env-var-lite path for nb06 (GITHUB_ACTIONS=true
+# triggers the light branch introduced in #233).
+#
+# Artifact naming (canonical name matters — Build Combined Doc's manual
+# workflow_dispatch path searches for the latest successful run of a
+# workflow that produced an artifact named "executed_nbs"):
+#
+#   push to main (success)             -> executed_nbs                    (400d)
+#   workflow_dispatch (success, clean)  -> executed_nbs                    (400d)
+#   workflow_dispatch (allow_errors=1)  -> executed_nbs-debug-<run_id>     (30d)
+#   pull_request (success)              -> executed_nbs-pr-<N>             (90d)
+#   any failure                         -> executed_nbs-failed-<run_id>    (30d)
 #
 # ── Policy: committed notebook outputs are decorative, not authoritative ──────
 # This artifact is the source of truth for downstream doc / RAG builds. The
@@ -28,17 +38,28 @@ on:
   push:
     branches: [main]
     # Trigger whenever ANY input that could change executed-notebook outputs
-    # changes. Kept in sync with the cache-key hashFiles below — if you add
-    # something here that affects outputs, add it to the cache key too, else
-    # a push could trigger this workflow but hit an old cache entry.
+    # changes. Kept in sync with the source-hash computation step below.
     paths:
       - 'docs/**/*.ipynb'                       # notebook source
       - 'src/**'                                # library that notebooks import
       - 'pyproject.toml'                        # runtime dependencies
       - 'docs/requirements.txt'                 # docs / exec-time dependencies
-      - 'docs/execute_notebooks.py'             # exec harness itself
-      - 'docs/check_executed_nbs.py'            # error gate
+      - 'docs/**/*.py'                          # exec harness, checkers, other doc scripts
       - 'Makefile'                              # NB_EXCLUDE / NB_TIMEOUT / other exec defaults
+      - '.github/workflows/execute-notebooks.yml'
+  pull_request:
+    branches: [main]
+    # PR validation: run execution + error gate so reviewers see notebook
+    # breakage before merge. Uploads to a PR-scoped artifact name so Build
+    # Combined Doc's "latest successful" search can't accidentally pick up
+    # PR-branch outputs.
+    paths:
+      - 'docs/**/*.ipynb'
+      - 'src/**'
+      - 'pyproject.toml'
+      - 'docs/requirements.txt'
+      - 'docs/**/*.py'
+      - 'Makefile'
       - '.github/workflows/execute-notebooks.yml'
   workflow_dispatch:
     inputs:
@@ -47,7 +68,7 @@ on:
         type: string
         default: '1800'
       allow_notebook_errors:
-        description: 'Publish artifact even if notebooks errored (for debugging).'
+        description: 'Publish artifact even if notebooks errored (for debugging). Skips the canonical artifact — debug output uploads under a distinct name.'
         type: boolean
         default: false
       force_reexecute:
@@ -72,11 +93,24 @@ jobs:
       - name: Install dependencies
         run: make docs-install
 
+      # Compute the source-hash ONCE, then reuse in both cache key and manifest.
+      # If you extend this list, extend both the paths filter above (push +
+      # pull_request) and the cache-key placeholder below.
+      - name: Compute source hash
+        id: source-hash
+        run: |
+          SOURCE_HASH="${{ hashFiles(
+            'docs/**/*.ipynb',
+            'src/**/*.py',
+            'pyproject.toml',
+            'docs/requirements.txt',
+            'docs/**/*.py',
+            'Makefile'
+          ) }}"
+          echo "hash=$SOURCE_HASH" >> "$GITHUB_OUTPUT"
+          echo "Source hash: $SOURCE_HASH"
+
       # Any change to the hashed inputs busts the cache and forces re-execution.
-      # Files hashed here MUST cover everything that can affect executed
-      # notebook outputs — else a change (e.g. to NB_EXCLUDE in the Makefile,
-      # or a new dep in docs/requirements.txt) would trigger this workflow via
-      # the paths filter above but still hit an old cache entry.
       # Bump the key prefix (executed-nbs-vN) to invalidate the whole cache
       # pool if the hashing set itself needs to change historic-state-wide.
       - name: Cache executed notebooks
@@ -85,15 +119,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: dist/executed_nbs
-          key: >-
-            executed-nbs-v2-${{ hashFiles(
-              'docs/**/*.ipynb',
-              'src/**/*.py',
-              'pyproject.toml',
-              'docs/requirements.txt',
-              'docs/execute_notebooks.py',
-              'Makefile'
-            ) }}
+          key: executed-nbs-v3-${{ steps.source-hash.outputs.hash }}
 
       - name: Execute notebooks (cache miss or forced)
         if: ${{ steps.nb-cache.outputs.cache-hit != 'true' || inputs.force_reexecute }}
@@ -104,18 +130,90 @@ jobs:
       # target has docs-executed-nbs as a prereq, which would force
       # re-execution even on cache hit.
       - name: Check for execution errors
+        id: check
         run: |
           python docs/check_executed_nbs.py dist/executed_nbs \
             ${{ inputs.allow_notebook_errors && '--allow-errors' || '' }}
 
-      # Upload regardless of check outcome so debug workflows can inspect the
-      # tracebacks in failed builds. 400 days = maximum retention on
-      # GitHub-hosted artifacts; these are the source-of-truth outputs for any
-      # downstream RAG / doc build.
-      - name: Upload executed notebooks
+      # Write a manifest so downstream consumers can verify provenance and
+      # detect stale-artifact drift on manual dispatch. Placed inside the
+      # artifact so `download-artifact` includes it automatically.
+      - name: Write artifact manifest
         if: always()
+        run: |
+          mkdir -p dist/executed_nbs
+          python <<PYEOF
+          import json, os, sys
+          from datetime import datetime, timezone
+          manifest = {
+              "schema_version": 1,
+              "commit_sha": "${{ github.sha }}",
+              "commit_ref": "${{ github.ref }}",
+              "source_hash": "${{ steps.source-hash.outputs.hash }}",
+              "python_version": sys.version.split()[0],
+              "run_id": "${{ github.run_id }}",
+              "run_number": ${{ github.run_number }},
+              "workflow_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "event_name": "${{ github.event_name }}",
+              "created_at": datetime.now(timezone.utc).isoformat(),
+              "was_cache_hit": ${{ steps.nb-cache.outputs.cache-hit == 'true' }},
+              "was_forced": ${{ inputs.force_reexecute || false }},
+              "was_allow_errors": ${{ inputs.allow_notebook_errors || false }},
+          }
+          with open("dist/executed_nbs/manifest.json", "w") as f:
+              json.dump(manifest, f, indent=2)
+          print("Wrote manifest:")
+          print(json.dumps(manifest, indent=2))
+          PYEOF
+
+      # ── Canonical upload: consumed by Build Combined Doc ──────────────────
+      # Only produced when we're confident the outputs represent a clean
+      # execution against a trusted branch state. push-to-main and clean
+      # workflow_dispatch (no error-allow) qualify; PR runs and debug
+      # dispatches do NOT — they upload under distinct names below.
+      - name: Upload executed notebooks (canonical)
+        if: >-
+          success()
+          && (
+            (github.event_name == 'push' && github.ref == 'refs/heads/main')
+            || (github.event_name == 'workflow_dispatch' && !inputs.allow_notebook_errors)
+          )
         uses: actions/upload-artifact@v4
         with:
           name: executed_nbs
           path: dist/executed_nbs
           retention-days: 400
+
+      # ── PR-scoped upload: reviewers can download to inspect ───────────────
+      # Distinct name means dawidd6/action-download-artifact's "latest
+      # successful" lookup on Build Combined Doc can't match this.
+      - name: Upload executed notebooks (PR validation)
+        if: success() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: executed_nbs-pr-${{ github.event.number }}
+          path: dist/executed_nbs
+          retention-days: 90
+
+      # ── Debug uploads: run-id-scoped, non-canonical ───────────────────────
+      # Debug dispatches (allow_notebook_errors=true) and any failure path
+      # upload here — reviewers can pull tracebacks without polluting the
+      # canonical artifact stream.
+      - name: Upload executed notebooks (debug dispatch)
+        if: >-
+          success()
+          && github.event_name == 'workflow_dispatch'
+          && inputs.allow_notebook_errors
+        uses: actions/upload-artifact@v4
+        with:
+          name: executed_nbs-debug-${{ github.run_id }}
+          path: dist/executed_nbs
+          retention-days: 30
+
+      - name: Upload executed notebooks (failure debug)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: executed_nbs-failed-${{ github.run_id }}
+          path: dist/executed_nbs
+          retention-days: 30

--- a/.github/workflows/execute-notebooks.yml
+++ b/.github/workflows/execute-notebooks.yml
@@ -9,6 +9,20 @@ name: Execute Notebooks
 # cache miss = full nbconvert --execute pass, currently ~25 min with the
 # env-var-lite path for nb06 (GITHUB_ACTIONS=true triggers the light branch
 # introduced in #233).
+#
+# ── Policy: committed notebook outputs are decorative, not authoritative ──────
+# This artifact is the source of truth for downstream doc / RAG builds. The
+# outputs field of committed .ipynb files under docs/tutorials/notebooks/
+# has NO effect on any CI-produced artifact and is kept only so browsing the
+# repo on github.com renders charts inline. Consequences:
+#   - Contributors MAY commit executed notebooks (for GitHub rendering).
+#   - Contributors MAY commit source-only notebooks (nbstripout, --ClearOutputPreprocessor).
+#   - Both work identically for the doc build. CI ignores committed outputs.
+#   - Committed outputs may drift from source; that's fine here because no
+#     downstream product reads them.
+# If a future decision requires strict source-only commits (e.g. to control
+# repo bloat), add a check step to github-actions.yml that fails PRs whose
+# notebooks contain non-empty outputs. Not enforced today.
 
 on:
   push:

--- a/.github/workflows/execute-notebooks.yml
+++ b/.github/workflows/execute-notebooks.yml
@@ -1,0 +1,90 @@
+name: Execute Notebooks
+
+# Executes every docs/**/*.ipynb and publishes the results as a workflow
+# artifact ("executed_nbs"). The Build Combined Doc workflow consumes this
+# artifact instead of re-executing notebooks on every doc build.
+#
+# Cache is keyed on a hash of everything that can affect notebook outputs
+# (notebook source, library source, dependencies). Cache hit = seconds;
+# cache miss = full nbconvert --execute pass, currently ~25 min with the
+# env-var-lite path for nb06 (GITHUB_ACTIONS=true triggers the light branch
+# introduced in #233).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**/*.ipynb'                       # notebook source changed
+      - 'src/**'                                # library that notebooks import changed
+      - 'pyproject.toml'                        # dependencies changed
+      - 'docs/execute_notebooks.py'             # exec harness itself changed
+      - 'docs/check_executed_nbs.py'            # error gate changed
+      - '.github/workflows/execute-notebooks.yml'
+  workflow_dispatch:
+    inputs:
+      nb_timeout:
+        description: 'Per-cell timeout (s). Heavy notebooks (nb04, nb05) benefit from 1800.'
+        type: string
+        default: '1800'
+      allow_notebook_errors:
+        description: 'Publish artifact even if notebooks errored (for debugging).'
+        type: boolean
+        default: false
+      force_reexecute:
+        description: 'Ignore the cache and re-execute all notebooks.'
+        type: boolean
+        default: false
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    env:
+      # Nb06's env-var toggle (#233) picks the CI-lite path (n_years=20, nsims=2)
+      # so the full pipeline stays under the ~40-min doc-build budget.
+      GITHUB_ACTIONS: 'true'
+    steps:
+      - uses: actions/checkout@v7.0.0
+
+      - uses: actions/setup-python@v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: make docs-install
+
+      # Any change to the hashed inputs busts the cache and forces re-execution.
+      # Bump the key prefix (executed-nbs-vN) to invalidate the whole cache pool
+      # if the executor itself is upgraded in a way we want to redo across all
+      # historic source states.
+      - name: Cache executed notebooks
+        id: nb-cache
+        if: ${{ !inputs.force_reexecute }}
+        uses: actions/cache@v4
+        with:
+          path: dist/executed_nbs
+          key: executed-nbs-v1-${{ hashFiles('docs/**/*.ipynb', 'src/**/*.py', 'pyproject.toml') }}
+
+      - name: Execute notebooks (cache miss or forced)
+        if: ${{ steps.nb-cache.outputs.cache-hit != 'true' || inputs.force_reexecute }}
+        run: make docs-executed-nbs NB_TIMEOUT=${{ inputs.nb_timeout || '1800' }}
+
+      # Gate: fail if any executed notebook contains error outputs. Invoke the
+      # underlying script directly rather than `make docs-check-nbs` — the make
+      # target has docs-executed-nbs as a prereq, which would force
+      # re-execution even on cache hit.
+      - name: Check for execution errors
+        run: |
+          python docs/check_executed_nbs.py dist/executed_nbs \
+            ${{ inputs.allow_notebook_errors && '--allow-errors' || '' }}
+
+      # Upload regardless of check outcome so debug workflows can inspect the
+      # tracebacks in failed builds. 400 days = maximum retention on
+      # GitHub-hosted artifacts; these are the source-of-truth outputs for any
+      # downstream RAG / doc build.
+      - name: Upload executed notebooks
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: executed_nbs
+          path: dist/executed_nbs
+          retention-days: 400

--- a/.github/workflows/execute-notebooks.yml
+++ b/.github/workflows/execute-notebooks.yml
@@ -17,8 +17,16 @@ name: Execute Notebooks
 #   push to main (success)             -> executed_nbs                    (400d)
 #   workflow_dispatch (success, clean)  -> executed_nbs                    (400d)
 #   workflow_dispatch (allow_errors=1)  -> executed_nbs-debug-<run_id>     (30d)
-#   pull_request (success)              -> executed_nbs-pr-<N>             (90d)
 #   any failure                         -> executed_nbs-failed-<run_id>    (30d)
+#
+# There is deliberately NO pull_request trigger. Executing every notebook
+# adds ~25 min of wall-clock per PR iteration, which is not affordable
+# during review cycles. Broken notebooks land on main and are surfaced by
+# the post-merge push run — worth the reduced pre-merge safety in exchange
+# for fast PR cycles. If a specific PR needs pre-merge validation, run
+# `make docs-jenner-execute` locally or trigger this workflow via manual
+# workflow_dispatch (on the PR branch's HEAD if committed to main first,
+# or against the merge-base for a preview).
 #
 # ── Policy: committed notebook outputs are decorative, not authoritative ──────
 # This artifact is the source of truth for downstream doc / RAG builds. The
@@ -46,20 +54,6 @@ on:
       - 'docs/requirements.txt'                 # docs / exec-time dependencies
       - 'docs/**/*.py'                          # exec harness, checkers, other doc scripts
       - 'Makefile'                              # NB_EXCLUDE / NB_TIMEOUT / other exec defaults
-      - '.github/workflows/execute-notebooks.yml'
-  pull_request:
-    branches: [main]
-    # PR validation: run execution + error gate so reviewers see notebook
-    # breakage before merge. Uploads to a PR-scoped artifact name so Build
-    # Combined Doc's "latest successful" search can't accidentally pick up
-    # PR-branch outputs.
-    paths:
-      - 'docs/**/*.ipynb'
-      - 'src/**'
-      - 'pyproject.toml'
-      - 'docs/requirements.txt'
-      - 'docs/**/*.py'
-      - 'Makefile'
       - '.github/workflows/execute-notebooks.yml'
   workflow_dispatch:
     inputs:
@@ -94,8 +88,8 @@ jobs:
         run: make docs-install
 
       # Compute the source-hash ONCE, then reuse in both cache key and manifest.
-      # If you extend this list, extend both the paths filter above (push +
-      # pull_request) and the cache-key placeholder below.
+      # If you extend this list, extend the push paths filter above too, so
+      # a change to any hashed input actually triggers a run.
       - name: Compute source hash
         id: source-hash
         run: |
@@ -183,17 +177,6 @@ jobs:
           name: executed_nbs
           path: dist/executed_nbs
           retention-days: 400
-
-      # ── PR-scoped upload: reviewers can download to inspect ───────────────
-      # Distinct name means dawidd6/action-download-artifact's "latest
-      # successful" lookup on Build Combined Doc can't match this.
-      - name: Upload executed notebooks (PR validation)
-        if: success() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
-        with:
-          name: executed_nbs-pr-${{ github.event.number }}
-          path: dist/executed_nbs
-          retention-days: 90
 
       # ── Debug uploads: run-id-scoped, non-canonical ───────────────────────
       # Debug dispatches (allow_notebook_errors=true) and any failure path

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 # work identically under bash, cmd.exe, and PowerShell — no SHELL override
 # needed. Multi-step logic lives in docs/*.py helpers instead of inline shell.
 
-.PHONY: help docs-install docs-build docs-executed-nbs docs-check-nbs docs-jenner clean-docs
+.PHONY: help docs-install docs-build docs-executed-nbs docs-check-nbs docs-jenner docs-jenner-artifact clean-docs
 
 PYTHON           ?= python
 SITE_DIR         ?= site
@@ -33,6 +33,8 @@ help:
 	@echo "  make docs-check-nbs      Fail if any executed notebook contains errors"
 	@echo "  make docs-jenner       Full pipeline (execute + check + build + concat)"
 	@echo "                           Output: $(COMBINED)"
+	@echo "  make docs-jenner-artifact  Build + concat only (assumes \$$(EXEC_DIR) pre-populated)"
+	@echo "                           Used by the Execute Notebooks -> Build Combined Doc CI chain"
 	@echo "  make clean-docs          Remove $(SITE_DIR)/, $(EXEC_DIR)/, $(COMBINED)"
 	@echo ""
 	@echo "Tunable variables (override on the command line):"
@@ -73,6 +75,16 @@ docs-check-nbs: docs-executed-nbs
 # independent of notebook execution (mkdocs-jupyter has execute:false and
 # reads the source .ipynb files directly), so it's safe to keep in parallel.
 docs-jenner: docs-check-nbs docs-build
+	$(PYTHON) -c "from pathlib import Path; Path('$(COMBINED)').parent.mkdir(parents=True, exist_ok=True)"
+	$(PYTHON) docs/concat_mkdocs.py $(SITE_DIR) $(EXEC_DIR) $(COMBINED)
+
+# ── Combined markdown from a pre-built executed-notebooks tree ────────────────
+# Same output as docs-jenner but skips both docs-executed-nbs and docs-check-nbs
+# — assumes $(EXEC_DIR) is already populated (typically by the Execute
+# Notebooks GitHub Action's artifact download). No execution, no error gate,
+# both already guaranteed upstream. Local users generally want `docs-jenner`
+# instead.
+docs-jenner-artifact: docs-build
 	$(PYTHON) -c "from pathlib import Path; Path('$(COMBINED)').parent.mkdir(parents=True, exist_ok=True)"
 	$(PYTHON) docs/concat_mkdocs.py $(SITE_DIR) $(EXEC_DIR) $(COMBINED)
 


### PR DESCRIPTION
## Summary

Splits notebook execution into its own workflow (`execute-notebooks.yml`) with a source-hash-keyed cache, publishes results as a 400-day GitHub Actions artifact, and reworks `build-combined-doc.yml` to consume that artifact instead of re-executing notebooks itself.

Closes #186 (notebook execution on doc PRs/merges) and solves two adjacent problems as a side effect.

## What this fixes

| Concern | Before | After |
|---|---|---|
| Notebooks executed on doc-merge builds | ❌ release-only | ✅ every main push touching notebook/library source |
| Committed notebook outputs must be kept fresh | manual convention | not required — CI artifact is source of truth |
| Every doc build re-executes notebooks | ✅ ~25 min | only when source hash changes |
| Executed-notebook access for debugging | latest-execute only | every successful run, 400-day retention |
| Doc build wall clock in common case | ~25 min | ~2-3 min (download + build + concat) |

## Workflow shape

```
Execute Notebooks
  ├─ trigger: push to main touching docs/**/*.ipynb, src/**, deps, exec scripts,
  │           Makefile, or execute-notebooks.yml itself. Also workflow_dispatch.
  │           No pull_request trigger — see the top-of-file comment for rationale.
  ├─ cache-key: hashFiles(all *.ipynb, src/**, pyproject.toml,
  │                       docs/requirements.txt, docs/**/*.py, Makefile,
  │                       .github/workflows/execute-notebooks.yml)
  ├─ cache miss: make docs-executed-nbs
  ├─ gate: python docs/check_executed_nbs.py (fails on any nb error)
  ├─ manifest: writes dist/executed_nbs/manifest.json with commit_sha,
  │             source_hash, run_id, python_version, event_name,
  │             was_cache_hit, was_forced, was_allow_errors
  └─ upload artifacts:
       - `executed_nbs` (400d) — only on success from push-to-main OR
                                 clean workflow_dispatch
       - `executed_nbs-debug-<run_id>` (30d) — debug dispatch with
                                               allow_notebook_errors=true
       - `executed_nbs-failed-<run_id>` (30d) — any failure path

Build Combined Doc
  ├─ trigger: workflow_run completion of Execute Notebooks (auto-chain,
  │           restricted to push-triggered upstream runs — debug dispatches
  │           can't auto-fire a laser-mcp sync)
  │           OR manual workflow_dispatch
  ├─ download executed_nbs artifact (no re-execution)
  ├─ provenance gate (workflow_dispatch only): compare artifact's
  │   manifest.source_hash to hashFiles() of the checkout; fail if they
  │   disagree unless `use_latest_anyway=true` is set
  └─ make docs-jenner-artifact → build site + concat → sync to laser-mcp
```

## Files changed

- **New:** `.github/workflows/execute-notebooks.yml` — cache + execute + check + manifest + conditional uploads.
- **Modified:** `.github/workflows/build-combined-doc.yml` — download artifact instead of re-executing, add `workflow_run.event == 'push'` guard on auto-chain, add manifest-based compatibility check on `workflow_dispatch`.
- **Modified:** `Makefile` — new `docs-jenner-artifact` target that runs build + concat only, assuming `$(EXEC_DIR)` is pre-populated by the artifact download. This is the sole Makefile change here — the existing `docs-jenner` full pipeline is untouched. #237 separately reworks `docs-jenner` into a fast path and adds `docs-jenner-execute`; the trio is only complete once both this PR and #237 land.

## Policy decision: committed outputs are decorative (Option A)

Documented inline in `execute-notebooks.yml`. Under this proposal:
- Committed executed-notebook outputs have NO effect on any CI-produced artifact.
- Contributors MAY commit executed notebooks (for GitHub-render friendliness) OR strip outputs (via `nbstripout`) — both work identically for the doc build.
- Repo bloat, PR-review-diff noise, and possible drift are accepted tradeoffs in exchange for zero-friction contributor workflow and inline GitHub notebook rendering.
- If future consensus reverses this to strict source-only commits (Option B), the enforcement point is one check step in `github-actions.yml`. Explicitly not enforced today.

## No pull_request trigger — deliberate

Executing every notebook adds ~25 min per PR iteration. That cost is not affordable during review cycles. Broken notebooks land on main and are surfaced by the post-merge push run within minutes. Local `make docs-jenner-execute` (available once #237 lands) or a manual `workflow_dispatch` on this workflow remain as pre-merge validation options for PRs that specifically need them.

## Bootstrap note

On first enable, `workflow_dispatch` on Build Combined Doc will fail cleanly (no prior successful Execute Notebooks artifact to consume — `if_no_artifact_found: fail` catches this). Kick off Execute Notebooks once manually to seed. After that, either trigger works.

## Third-party action

`dawidd6/action-download-artifact@v3` — needed because `actions/download-artifact` only fetches from the current run or a known run-id, and `workflow_dispatch` on Build Combined Doc has no upstream run-id to point at. This third-party action searches for "latest successful run of workflow X" — exactly the semantics we need. Widely used (~4M weekly downloads); if you'd rather avoid the dep, we can write ~20 lines of `gh api` to find and fetch the latest artifact ID.

## Merge order with in-flight PRs

- **Independent** of #204 (plot descriptions), #240 (figtext form of #204), and #236 (concat improvements) — those change notebook / concat content; this changes CI plumbing.
- **Compatible with #237** (skip re-exec in `docs-jenner`) — #237 is about local dev workflow (renames current `docs-jenner` to `docs-jenner-execute`, makes new fast `docs-jenner`); this PR replaces CI-side reasoning about executed outputs entirely. Both land cleanly, and together produce a clean trio:
  - `make docs-jenner` — local fast path, committed outputs (per #237)
  - `make docs-jenner-execute` — local full pipeline (per #237)
  - `make docs-jenner-artifact` — CI path, assumes `$(EXEC_DIR)` pre-populated (this PR)

## Test plan

- [x] YAML validity confirmed on both workflow files.
- [x] `make help` shows the new target.
- [x] Both `hashFiles` lists (cache key in execute-notebooks + compat check in build-combined-doc) are literal duplicates: 7 patterns in same order.
- [ ] After merging, kick off Execute Notebooks manually to bootstrap the first artifact.
- [ ] Verify Build Combined Doc auto-triggers on Execute Notebooks completion.
- [ ] Verify Build Combined Doc `workflow_dispatch` grabs the most recent artifact and passes the compat check.
- [ ] Verify cache hits on a no-notebook-change push (workflow completes in seconds).
- [ ] Verify cache miss on a notebook edit (full ~25 min re-execution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)