### PR TITLE
docs: surface Execute Notebooks artifact via badge + folder README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Documentation Build Status](https://github.com/laser-base/laser-generic/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/laser-base/laser-generic/actions/workflows/pages/pages-build-deployment)
 [![build](https://github.com/laser-base/laser-generic/actions/workflows/github-actions.yml/badge.svg?branch=main)](https://github.com/laser-base/laser-generic/actions/workflows/github-actions.yml)
+[![Execute Notebooks](https://github.com/laser-base/laser-generic/actions/workflows/execute-notebooks.yml/badge.svg?branch=main)](https://github.com/laser-base/laser-generic/actions/workflows/execute-notebooks.yml)
 [![Coverage Status](https://codecov.io/gh/laser-base/laser-generic/branch/main/graphs/badge.svg?branch=main)](https://app.codecov.io/github/laser-base/laser-generic)
 [![PyPI Package latest release](https://img.shields.io/pypi/v/laser-generic.svg)](https://test.pypi.org/project/laser-generic)
 [![PyPI Wheel](https://img.shields.io/pypi/wheel/laser-generic.svg)](https://test.pypi.org/project/laser-generic)
@@ -123,3 +124,15 @@ uv pip install -e ".[dev]"
 #### Running Tests
 
 Now you can run tests in the `tests` directory or run the entire check+docs+test suite with ```tox```. Running ```tox``` will run several consistency checks, build documentation, run tests against the supported versions of Python, and create a code coverage report based on the test suite. Note that the first run of ```tox``` may take a few minutes (~5). Subsequent runs should be quicker depending on the speed of your machine and the test suite (~2 minutes). You can use ```tox``` to run tests against a single version of Python with, for example, ```tox -e py312```.
+
+## Executed notebook artifacts
+
+The tutorial notebooks under [`docs/tutorials/notebooks/`](docs/tutorials/notebooks/) are executed in CI by the [Execute Notebooks](.github/workflows/execute-notebooks.yml) workflow on every push to `main` that touches notebook or library source. Each run publishes an `executed_nbs` artifact containing every notebook re-executed against that commit, plus a `manifest.json` recording provenance (commit SHA, source hash, Python version, cache-hit status).
+
+**To download the latest executed notebooks:**
+
+1. Open the [latest successful Execute Notebooks run](https://github.com/laser-base/laser-generic/actions/workflows/execute-notebooks.yml?query=is%3Asuccess+branch%3Amain).
+2. Scroll to the *Artifacts* panel at the bottom of the run's summary page.
+3. Click `executed_nbs` (retention: 400 days) to download a zip of all executed notebooks.
+
+The rendered notebook pages on the [documentation site](https://laser.idmod.org/laser-generic) come from the same artifact — see the [`Build Combined Doc`](.github/workflows/build-combined-doc.yml) workflow for how the artifact feeds the doc build. If you need to inspect a specific commit's outputs (e.g. to debug a doc-quality regression), each artifact's `manifest.json` tells you which commit it was executed against.

--- a/docs/tutorials/notebooks/README.md
+++ b/docs/tutorials/notebooks/README.md
@@ -1,0 +1,58 @@
+# Tutorial notebooks
+
+This folder holds the Jupyter notebooks used as `laser-generic` tutorials. They cover single-patch and multi-patch SI / SIR / SEIR / SEIRS dynamics, births and deaths, seasonality, calibration, and case studies like the England-and-Wales measles pre-vaccine record.
+
+## Where do I read them?
+
+- **Rendered on the docs site (recommended for browsing):** [laser.idmod.org/laser-generic → tutorials](https://laser.idmod.org/laser-generic/tutorials/).
+- **Rendered inline on GitHub:** open any `*.ipynb` file in this folder. Note that committed outputs are decorative — they may be stale relative to the current source. See "Provenance" below.
+- **Executed against a specific commit:** see the artifact section below.
+
+## Source vs outputs — what's authoritative?
+
+**Source is authoritative. Committed outputs are decorative.**
+
+The tutorial notebooks are executed in CI by the [Execute Notebooks](../../../.github/workflows/execute-notebooks.yml) workflow. That workflow runs on every push to `main` that touches notebook or library source, publishes an `executed_nbs` artifact, and feeds that artifact into the doc-site build. The rendered figures you see at `laser.idmod.org/laser-generic` come from that artifact, not from the `outputs` field of the committed notebook files.
+
+That means:
+- Contributors may commit executed notebooks (nice for GitHub inline rendering) OR strip outputs (nice for lean diffs) — both work identically for the doc build.
+- Committed outputs may drift from source over time. That's OK, because no downstream product reads them.
+- The source-of-truth executed notebooks live in the CI artifact.
+
+## Downloading the executed notebooks
+
+If you want a specific commit's freshly-executed notebooks (e.g. to debug a doc-quality regression, or to preview what the docs will render against a change), grab them from the workflow's artifact panel:
+
+1. Open the [Execute Notebooks workflow runs](https://github.com/laser-base/laser-generic/actions/workflows/execute-notebooks.yml).
+2. Filter for the branch or commit you care about; the latest successful main-push run is [here](https://github.com/laser-base/laser-generic/actions/workflows/execute-notebooks.yml?query=is%3Asuccess+branch%3Amain).
+3. Scroll to the *Artifacts* panel and click `executed_nbs`.
+4. Retention is 400 days.
+
+## Provenance
+
+Each `executed_nbs` artifact includes a `manifest.json` at its root with:
+
+- `commit_sha`, `commit_ref` — the exact tree the outputs were built against.
+- `source_hash` — the hash used as the cache key. Two artifacts with the same `source_hash` were built from byte-identical inputs.
+- `python_version` — the Python that executed the cells.
+- `run_id`, `run_number`, `workflow_url` — back-links to the CI run.
+- `was_cache_hit`, `was_forced`, `was_allow_errors` — provenance flags.
+
+If you're doing bisection or comparing corpora across time, the `source_hash` and `commit_sha` are the two fields to trust.
+
+## Regenerating locally
+
+To execute the notebooks locally against a specific check-out:
+
+```
+make docs-executed-nbs           # populates dist/executed_nbs/
+make docs-check-nbs              # fail if any notebook errored
+```
+
+Or run the full local doc pipeline:
+
+```
+make docs-jenner-execute         # (available once #237 lands) execute + check + build + concat
+```
+
+Set `GITHUB_ACTIONS=true` in the environment to force `nb06`'s env-var-lite path (n_years=20, nsims=2) — matches what CI does. Without it, `nb06` runs at full scale (n_years=100, nsims=10, ~15 min).


### PR DESCRIPTION
## Summary

Follow-up to #241. Makes the executed-notebooks artifact discoverable from two places without touching CI logic.

## Changes

- **`README.md`**
  - Adds an `Execute Notebooks` status badge alongside the existing build / coverage badges.
  - Adds an `## Executed notebook artifacts` section explaining what the artifact is, how to grab it, and pointing at `manifest.json` for provenance.
- **`docs/tutorials/notebooks/README.md`** (new file)
  - Folder-local pointer to the same artifact download flow.
  - Clarifies the "committed outputs are decorative, source is authoritative" policy so contributors don't have to fight committed-output drift.
  - Documents the `manifest.json` fields (commit_sha, source_hash, python_version, run_id, etc.).
  - Shows local regeneration commands including the `GITHUB_ACTIONS=true` toggle for nb06's lite path.

Renders on github.com at the folder view — anyone browsing `docs/tutorials/notebooks/` sees the same guidance a docs-site reader would.

## Notes

- Not on mkdocs nav — the folder-README is intended for the GitHub-repo audience (contributors, code reviewers). If we want it on the site too, easy follow-up to add `docs/tutorials/notebooks/index.md` with the same content.
- References `make docs-jenner-execute` as an option, with a parenthetical noting it lands with #237. If #237 merges first, that parenthetical can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)