### PR TITLE
hotfix: manifest.json write — pass GHA values via env vars (avoids lowercase-boolean NameError)

### DIFF
--- a/.github/workflows/execute-notebooks.yml
+++ b/.github/workflows/execute-notebooks.yml
@@ -133,27 +133,44 @@ jobs:
       # Write a manifest so downstream consumers can verify provenance and
       # detect stale-artifact drift on manual dispatch. Placed inside the
       # artifact so `download-artifact` includes it automatically.
+      #
+      # GHA-evaluated booleans (`${{ ... }}`) render as lowercase `true`/`false`
+      # which are invalid Python identifiers; pass them via env vars and parse
+      # in Python instead of substituting into the source directly.
       - name: Write artifact manifest
         if: always()
+        env:
+          MANIFEST_COMMIT_SHA: ${{ github.sha }}
+          MANIFEST_COMMIT_REF: ${{ github.ref }}
+          MANIFEST_SOURCE_HASH: ${{ steps.source-hash.outputs.hash }}
+          MANIFEST_RUN_ID: ${{ github.run_id }}
+          MANIFEST_RUN_NUMBER: ${{ github.run_number }}
+          MANIFEST_WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          MANIFEST_EVENT_NAME: ${{ github.event_name }}
+          MANIFEST_WAS_CACHE_HIT: ${{ steps.nb-cache.outputs.cache-hit == 'true' }}
+          MANIFEST_WAS_FORCED: ${{ inputs.force_reexecute || false }}
+          MANIFEST_WAS_ALLOW_ERRORS: ${{ inputs.allow_notebook_errors || false }}
         run: |
           mkdir -p dist/executed_nbs
-          python <<PYEOF
+          python <<'PYEOF'
           import json, os, sys
           from datetime import datetime, timezone
+          def as_bool(name):
+              return os.environ.get(name, "").strip().lower() == "true"
           manifest = {
               "schema_version": 1,
-              "commit_sha": "${{ github.sha }}",
-              "commit_ref": "${{ github.ref }}",
-              "source_hash": "${{ steps.source-hash.outputs.hash }}",
+              "commit_sha": os.environ["MANIFEST_COMMIT_SHA"],
+              "commit_ref": os.environ["MANIFEST_COMMIT_REF"],
+              "source_hash": os.environ["MANIFEST_SOURCE_HASH"],
               "python_version": sys.version.split()[0],
-              "run_id": "${{ github.run_id }}",
-              "run_number": ${{ github.run_number }},
-              "workflow_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-              "event_name": "${{ github.event_name }}",
+              "run_id": os.environ["MANIFEST_RUN_ID"],
+              "run_number": int(os.environ["MANIFEST_RUN_NUMBER"]),
+              "workflow_url": os.environ["MANIFEST_WORKFLOW_URL"],
+              "event_name": os.environ["MANIFEST_EVENT_NAME"],
               "created_at": datetime.now(timezone.utc).isoformat(),
-              "was_cache_hit": ${{ steps.nb-cache.outputs.cache-hit == 'true' }},
-              "was_forced": ${{ inputs.force_reexecute || false }},
-              "was_allow_errors": ${{ inputs.allow_notebook_errors || false }},
+              "was_cache_hit": as_bool("MANIFEST_WAS_CACHE_HIT"),
+              "was_forced": as_bool("MANIFEST_WAS_FORCED"),
+              "was_allow_errors": as_bool("MANIFEST_WAS_ALLOW_ERRORS"),
           }
           with open("dist/executed_nbs/manifest.json", "w") as f:
               json.dump(manifest, f, indent=2)


### PR DESCRIPTION
## Summary

Hotfix for the failed bootstrap Execute Notebooks run after #241 (run [29054294479](https://github.com/laser-base/laser-generic/actions/runs/29054294479)).

The manifest-write step's heredoc substituted `\${{ ... }}` expressions directly into Python source. GHA-native booleans render as lowercase `true`/`false`, which are invalid Python identifiers:

```
Traceback (most recent call last):
  File "<stdin>", line 14, in <module>
NameError: name 'false' is not defined. Did you mean: 'False'?
```

Line 14 was `"was_cache_hit": false,`.

## Fix

Pass every substitution through `env:` block, read via `os.environ` in Python, and route booleans through an `as_bool()` helper that compares against the string `"true"`. Removes the substitution-into-source hazard entirely — no future field addition can silently break the surrounding Python.

Verified locally by running the step's Python code with representative env values → produces a valid `manifest.json`.

## Safety mechanism worked

Confirms the failure-path design of #241:
- Only the non-canonical `executed_nbs-failed-29054294479` artifact was uploaded (via `if: failure()` branch), NOT the canonical `executed_nbs`.
- Build Combined Doc's `workflow_run` trigger saw `conclusion: failure` on the upstream run and correctly skipped its job.
- No half-baked artifact went downstream to laser-mcp.

Just the manifest step itself needs the fix.

## Follow-ups after this lands

1. Re-run Execute Notebooks on main (auto-fires on this PR's merge).
2. Verify `executed_nbs` (canonical, 400d) uploads.
3. Verify `manifest.json` inside the artifact has valid JSON.
4. Verify Build Combined Doc auto-fires and creates the laser-mcp sync PR.
5. Confirm cache-hit sanity by triggering a second Execute Notebooks with no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)