### PR TITLE
ci(docs-site): overlay executed_nbs artifact before mkdocs build

### DIFF
--- a/.github/workflows/mkdocs-ghp.yml
+++ b/.github/workflows/mkdocs-ghp.yml
@@ -35,7 +35,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: write   # mkdocs gh-deploy pushes to the gh-pages branch
+  actions: read     # both download-artifact steps need this to fetch executed_nbs
+                    # from Execute Notebooks runs (otherwise 403 at runtime)
 
 concurrency:
   group: gh-pages-deploy

--- a/.github/workflows/mkdocs-ghp.yml
+++ b/.github/workflows/mkdocs-ghp.yml
@@ -1,16 +1,58 @@
 name: MkDocs Deploy
+
+# Deploys the docs site (laser.idmod.org/laser-generic) to GitHub Pages.
+#
+# Before building, this workflow overlays the latest successful
+# `executed_nbs` artifact from the Execute Notebooks workflow onto the
+# committed docs/ tree, so mkdocs-jupyter's `execute: false` setting can
+# render notebook pages with fresh (CI-executed) outputs instead of
+# whatever decorative outputs happen to be committed.
+#
+# Trigger matrix:
+#   push to main                        → deploy with latest available artifact
+#   workflow_run: Execute Notebooks     → deploy with THAT run's artifact,
+#                                          restricted to push-triggered upstream
+#   workflow_dispatch                   → deploy with latest available artifact
+#
+# On bootstrap (no artifact exists yet), the download step warns and the
+# build proceeds with committed decorative outputs — same behavior as
+# before this workflow was updated.
+#
+# Concurrency: the gh-pages-deploy group with cancel-in-progress: true
+# means a push-triggered deploy that starts before Execute Notebooks
+# finishes will be superseded when the workflow_run chain fires with the
+# fresher artifact.
+
 on:
   push:
     branches:
       - master
       - main
+  workflow_run:
+    workflows: ["Execute Notebooks"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
 permissions:
   contents: write
+
 concurrency:
   group: gh-pages-deploy
   cancel-in-progress: true
+
 jobs:
   deploy:
+    # Skip auto-chain from failed or dispatch-triggered Execute Notebooks
+    # runs — a debug dispatch (allow_notebook_errors=true or
+    # force_reexecute=true) shouldn't publish a possibly-suspect site.
+    # Push and workflow_dispatch triggers on this workflow pass trivially.
+    if: >-
+      github.event_name != 'workflow_run'
+      || (
+        github.event.workflow_run.conclusion == 'success'
+        && github.event.workflow_run.event == 'push'
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0
@@ -30,8 +72,68 @@ jobs:
             mkdocs-material-
       - run: |
           pip install --index-url https://packages.idmod.org/artifactory/api/pypi/pypi-production/simple -e ".[docs]"
+
+      # Download the executed notebooks so mkdocs-jupyter renders them with
+      # fresh CI-executed outputs (matching what Build Combined Doc feeds
+      # into the RAG corpus). Two paths depending on trigger:
+      #   workflow_run: fetch that specific upstream run's artifact by ID.
+      #   push / workflow_dispatch: fetch the latest successful Execute
+      #     Notebooks run's artifact (may be from an earlier commit if
+      #     this push doesn't affect notebook execution paths — that's
+      #     the right behavior for docs-only edits).
+      - name: Download executed notebooks (from triggering run)
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          name: executed_nbs
+          path: dist/executed_nbs
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download executed notebooks (latest successful)
+        if: github.event_name != 'workflow_run'
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: execute-notebooks.yml
+          name: executed_nbs
+          path: dist/executed_nbs
+          workflow_conclusion: success
+          # Bootstrap-safe: on first deploy (no prior artifact) OR on a
+          # deploy for a docs-only change with no fresh execution yet,
+          # emit a warning and continue with committed decorative outputs.
+          if_no_artifact_found: warn
+
+      # Overlay every .ipynb from the artifact onto its committed
+      # counterpart under docs/. The artifact preserves the docs/ layout
+      # (dist/executed_nbs/tutorials/notebooks/*.ipynb etc.), so a targeted
+      # per-file copy keeps the docs/ tree intact and only refreshes
+      # notebook contents.
+      - name: Overlay executed notebooks onto docs/
+        if: hashFiles('dist/executed_nbs/**/*.ipynb') != ''
+        run: |
+          count=0
+          while IFS= read -r -d '' src; do
+              rel="${src#dist/executed_nbs/}"
+              dest="docs/$rel"
+              mkdir -p "$(dirname "$dest")"
+              cp "$src" "$dest"
+              count=$((count + 1))
+          done < <(find dist/executed_nbs -name '*.ipynb' -print0)
+          echo "Overlaid $count executed notebooks onto docs/."
+          if [ -f dist/executed_nbs/manifest.json ]; then
+              echo "Artifact manifest:"
+              cat dist/executed_nbs/manifest.json
+          fi
+
+      - name: Note if artifact was unavailable
+        if: hashFiles('dist/executed_nbs/**/*.ipynb') == ''
+        run: |
+          echo "::warning::No executed_nbs artifact was overlaid. Building with committed decorative outputs."
+          echo "::warning::This can happen on first bootstrap or if Execute Notebooks hasn't run successfully yet."
+
       - name: Build MkDocs site
         run: mkdocs build
+
       - name: Assert API reference content floor
         run: |
           ref_count=$(find site/reference -name 'index.html' 2>/dev/null | wc -l)
@@ -40,5 +142,6 @@ jobs:
             echo "ERROR: site/reference is degraded (only $ref_count pages, expected 30+)"
             exit 1
           fi
+
       - name: Deploy to GitHub Pages
         run: mkdocs gh-deploy --force --dirty


### PR DESCRIPTION
## Summary

Fixes a gap uncovered while writing #245. The docs site at [`laser.idmod.org/laser-generic`](https://laser.idmod.org/laser-generic) was being built with `mkdocs-jupyter execute: false`, which meant it rendered whatever notebook `outputs` were committed under `docs/tutorials/notebooks/*.ipynb`. Under the "committed outputs are decorative" policy adopted in #241, those may drift from source — so the docs site could show stale figures while the RAG corpus (fed by the `executed_nbs` artifact via Build Combined Doc) had fresh ones.

This aligns the two chains under the same policy: **the `executed_nbs` artifact is the source of truth for everything user-facing.**

## What changes

`.github/workflows/mkdocs-ghp.yml`:

- Adds `workflow_run` (Execute Notebooks completion) and `workflow_dispatch` triggers alongside the existing `push` trigger.
- Restricts the `workflow_run` auto-chain to push-triggered, successful upstream Execute Notebooks runs (same guard as Build Combined Doc — debug dispatches don't auto-publish).
- Adds a step to download the executed notebooks:
  - `workflow_run` path: fetches by `run-id` from the triggering upstream run.
  - `push` / `workflow_dispatch` path: fetches "latest successful" via `dawidd6/action-download-artifact`. `if_no_artifact_found: warn` — bootstrap-safe.
- Adds a step to overlay every `.ipynb` from the artifact onto its committed counterpart under `docs/`, preserving layout. Only touches `.ipynb` files; nothing else in `docs/` is disturbed.
- Existing steps unchanged: mkdocs cache, install, build, API-reference floor check, deploy.

The concurrency group (`gh-pages-deploy`, `cancel-in-progress: true`) already handles the overlap case: a push-triggered deploy that starts before Execute Notebooks finishes will be cancelled by the workflow_run chain firing with the fresher artifact.

## Effect

After this lands:

| Location | Source of figures | Fresh? |
|---|---|---|
| Docs site `laser.idmod.org/…` | Execute Notebooks artifact (overlaid onto docs/) | ✅ **Yes** (was: ❌ committed outputs) |
| RAG corpus in laser-mcp | Execute Notebooks artifact | ✅ Yes (unchanged) |
| Committed `.ipynb` on github.com | Committed decorative outputs | ❌ No (still Option A — unchanged) |

The docs site row moves from "stale" to "fresh". The other two rows are unchanged.

## Bootstrap safety

- If no `executed_nbs` artifact exists (very first deploy after enabling this workflow), `if_no_artifact_found: warn` on the fallback download path means the step succeeds. The overlay step is a no-op (no `.ipynb` files under `dist/executed_nbs/` because nothing was downloaded). The site still builds with committed decorative outputs, emitting a warning in the Actions log.
- Once Execute Notebooks has run at least once, every subsequent deploy benefits from the overlay.

## Follow-up

After this merges, PR #245 (README reframe) becomes fully accurate — the docs-site row of its source-of-truth table becomes true. #245 currently claims it, this PR makes it so.