### PR TITLE
hotfix(ci): narrow Execute Notebooks triggers (concat_mkdocs.py is not an execution input)

### DIFF
--- a/.github/workflows/build-combined-doc.yml
+++ b/.github/workflows/build-combined-doc.yml
@@ -87,7 +87,7 @@ jobs:
             'src/**/*.py',
             'pyproject.toml',
             'docs/requirements.txt',
-            'docs/**/*.py',
+            'docs/execute_notebooks.py',
             'Makefile',
             '.github/workflows/execute-notebooks.yml'
           ) }}"

--- a/.github/workflows/execute-notebooks.yml
+++ b/.github/workflows/execute-notebooks.yml
@@ -46,13 +46,23 @@ on:
   push:
     branches: [main]
     # Trigger whenever ANY input that could change executed-notebook outputs
-    # changes. Kept in sync with the source-hash computation step below.
+    # OR the pass/fail verdict on those outputs changes. Narrower than the
+    # source-hash below because the check script affects the verdict but not
+    # the outputs — hitting the cache and re-running the check with a new
+    # gate is desired.
+    #
+    # Deliberately DOES NOT include docs/**/*.py (too broad) — that would
+    # fire on concat_mkdocs.py edits, which is a post-execution assembly
+    # step and doesn't affect notebook outputs. Concat changes should
+    # trigger Build Combined Doc + MkDocs Deploy (both consume the
+    # artifact separately), not re-execution.
     paths:
       - 'docs/**/*.ipynb'                       # notebook source
       - 'src/**'                                # library that notebooks import
       - 'pyproject.toml'                        # runtime dependencies
       - 'docs/requirements.txt'                 # docs / exec-time dependencies
-      - 'docs/**/*.py'                          # exec harness, checkers, other doc scripts
+      - 'docs/execute_notebooks.py'             # the executor itself
+      - 'docs/check_executed_nbs.py'            # the pass/fail gate
       - 'Makefile'                              # NB_EXCLUDE / NB_TIMEOUT / other exec defaults
       - '.github/workflows/execute-notebooks.yml'
   workflow_dispatch:
@@ -90,6 +100,11 @@ jobs:
       # Compute the source-hash ONCE, then reuse in both cache key and manifest.
       # If you extend this list, extend the push paths filter above too, so
       # a change to any hashed input actually triggers a run.
+      # Files hashed here are the ones whose changes affect executed-notebook
+      # outputs. NARROWER than the push paths filter above by design — the
+      # check script (docs/check_executed_nbs.py) can trigger a run to
+      # re-verify the gate, but doesn't affect outputs, so a cache hit is
+      # desirable in that case.
       - name: Compute source hash
         id: source-hash
         run: |
@@ -98,7 +113,7 @@ jobs:
             'src/**/*.py',
             'pyproject.toml',
             'docs/requirements.txt',
-            'docs/**/*.py',
+            'docs/execute_notebooks.py',
             'Makefile',
             '.github/workflows/execute-notebooks.yml'
           ) }}"
@@ -114,7 +129,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: dist/executed_nbs
-          key: executed-nbs-v4-${{ steps.source-hash.outputs.hash }}
+          key: executed-nbs-v5-${{ steps.source-hash.outputs.hash }}
 
       - name: Execute notebooks (cache miss or forced)
         if: ${{ steps.nb-cache.outputs.cache-hit != 'true' || inputs.force_reexecute }}


### PR DESCRIPTION
## Summary

Fixes a real bug caught by @jonathanhhb on the #236 merge: the paths filter and hashFiles set in \`execute-notebooks.yml\` both used \`docs/**/*.py\` as a catch-all. That matched \`docs/concat_mkdocs.py\`, which is a **post-execution assembly step** — it reads the executed notebooks and produces the combined markdown corpus, but doesn't affect notebook execution outputs.

Symptom: the #236 merge (which only touched concat_mkdocs.py) fired a full Execute Notebooks run, wasting ~25 min of runner time to regenerate byte-identical executed notebooks.

The concat script's changes should trigger Build Combined Doc (RAG corpus rebuild) and MkDocs Deploy (docs site rebuild), both of which already consume the artifact independently — but NOT re-execution.

## What changes

| File | Before | After |
|---|---|---|
| \`execute-notebooks.yml\` paths filter | \`docs/**/*.py\` | \`docs/execute_notebooks.py\` + \`docs/check_executed_nbs.py\` |
| \`execute-notebooks.yml\` hashFiles | \`docs/**/*.py\` | \`docs/execute_notebooks.py\` only |
| \`build-combined-doc.yml\` compat-check hashFiles | \`docs/**/*.py\` | \`docs/execute_notebooks.py\` only |
| Cache key prefix | \`executed-nbs-v4-\` | \`executed-nbs-v5-\` |

## Why the check script is in paths filter but NOT in hashFiles

- The check script controls the pass/fail verdict against already-computed outputs, but doesn't change the outputs themselves.
- Paths filter: YES — a gate change should re-run to re-verify current outputs.
- HashFiles: NO — cache should hit (identical outputs), check step runs with the new gate against the restored outputs. This is exactly what we want.

## One-time cost

Because hashFiles algorithm changed, the first push after this merges will do a full ~25 min re-execution to seed the v5 cache pool. Unavoidable one-time cost of the algorithm change.

Because this PR touches \`.github/workflows/execute-notebooks.yml\` itself, the merge triggers execution automatically (workflow-file change is in the paths filter). After that lands, downstream Build Combined Doc + MkDocs Deploy will auto-chain with the new v5 artifact and pick up the #236 concat changes.

## What this prevents going forward

- \`docs/concat_mkdocs.py\` changes → do NOT trigger execution ✅
- Other doc-side python scripts (future additions) → do NOT trigger execution ✅
- Notebook or library source changes → still trigger execution ✅
- Executor or gate script changes → still trigger execution ✅